### PR TITLE
Bugfix: Incorrect duration with track containing multiple segments

### DIFF
--- a/fittrackee/tests/fixtures/fixtures_workouts.py
+++ b/fittrackee/tests/fixtures/fixtures_workouts.py
@@ -703,6 +703,62 @@ def gpx_file_with_segments() -> str:
 
 
 @pytest.fixture()
+def gpx_file_with_3_segments() -> str:
+    """60 seconds between each segment"""
+    return (
+        '<?xml version=\'1.0\' encoding=\'UTF-8\'?>'
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '  <metadata/>'
+        '  <trk>'
+        '    <name>just a workout</name>'
+        '    <trkseg>'
+        '      <trkpt lat="44.68095" lon="6.07367">'
+        '        <ele>998</ele>'
+        '        <time>2018-03-13T12:44:50Z</time>'
+        '      </trkpt>'
+        '      <trkpt lat="44.68091" lon="6.07367">'
+        '        <ele>998</ele>'
+        '        <time>2018-03-13T12:44:55Z</time>'
+        '      </trkpt>'
+        '      <trkpt lat="44.6808" lon="6.07364">'
+        '        <ele>994</ele>'
+        '        <time>2018-03-13T12:45:00Z</time>'
+        '      </trkpt>'
+        '    </trkseg>'
+        '    <trkseg>'
+        '      <trkpt lat="44.67972" lon="6.07367">'
+        '        <ele>987</ele>'
+        '        <time>2018-03-13T12:46:00Z</time>'
+        '      </trkpt>'
+        '      <trkpt lat="44.67966" lon="6.07368">'
+        '        <ele>987</ele>'
+        '        <time>2018-03-13T12:46:05Z</time>'
+        '      </trkpt>'
+        '      <trkpt lat="44.67961" lon="6.0737">'
+        '        <ele>986</ele>'
+        '        <time>2018-03-13T12:46:10Z</time>'
+        '      </trkpt>'
+        '    </trkseg>'
+        '    <trkseg>'
+        '      <trkpt lat="44.67858" lon="6.07425">'
+        '        <ele>980</ele>'
+        '        <time>2018-03-13T12:47:10Z</time>'
+        '      </trkpt>'
+        '      <trkpt lat="44.67842" lon="6.07434">'
+        '        <ele>979</ele>'
+        '        <time>2018-03-13T12:47:15Z</time>'
+        '      </trkpt>'
+        '      <trkpt lat="44.67837" lon="6.07435">'
+        '        <ele>979</ele>'
+        '        <time>2018-03-13T12:47:20Z</time>'
+        '      </trkpt>'
+        '    </trkseg>'
+        '  </trk>'
+        '</gpx>'
+    )
+
+
+@pytest.fixture()
 def gpx_file_storage(gpx_file: str) -> FileStorage:
     return FileStorage(
         filename=f'{uuid4().hex}.gpx', stream=BytesIO(str.encode(gpx_file))

--- a/fittrackee/workouts/utils/gpx.py
+++ b/fittrackee/workouts/utils/gpx.py
@@ -104,7 +104,9 @@ def get_gpx_info(
                 # if a previous segment exists, calculate stopped time between
                 # the two segments
                 if prev_seg_last_point:
-                    stopped_time_between_seg = point.time - prev_seg_last_point
+                    stopped_time_between_seg += (
+                        point.time - prev_seg_last_point
+                    )
 
             # last segment point
             if point_idx == (segment_points_nb - 1):


### PR DESCRIPTION
While inspecting the gpx handling, I found a bug:
The variable `stopped_time_between_seg` contains only the time between the _latest two segments_ and passes them to `get_gpx_data`.

This is not an issue, if the track contains only one or two segments. But if there are more, the additional calculations are incorrect.

The changed code aggregates the time between all segments now.