### PR TITLE
API - save segment duration w/o microseconds

### DIFF
--- a/fittrackee/tests/workouts/test_utils/test_workouts.py
+++ b/fittrackee/tests/workouts/test_utils/test_workouts.py
@@ -1,12 +1,16 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from statistics import mean
 from typing import List, Union
 
 import pytest
 import pytz
+from flask import Flask
 from gpxpy.gpxfield import SimpleTZ
 
+from fittrackee.users.models import User
+from fittrackee.workouts.models import Sport, Workout
 from fittrackee.workouts.utils.workouts import (
+    create_segment,
     get_average_speed,
     get_workout_datetime,
 )
@@ -113,3 +117,34 @@ class TestWorkoutGetWorkoutDatetime:
         )
 
         assert workout_date_with_tz is None
+
+
+class TestCreateSegment:
+    def test_it_removes_microseconds(
+        self,
+        app: Flask,
+        user_1: User,
+        sport_1_cycling: Sport,
+        workout_cycling_user_1: Workout,
+    ) -> None:
+        duration = timedelta(seconds=3600, microseconds=100)
+
+        segment = create_segment(
+            workout_id=workout_cycling_user_1.id,
+            workout_uuid=workout_cycling_user_1.uuid,
+            segment_data={
+                'idx': 0,
+                'duration': duration,
+                'distance': 10,
+                'stop_time': timedelta(seconds=0),
+                'moving_time': duration,
+                'elevation_min': None,
+                'elevation_max': None,
+                'downhill': None,
+                'uphill': None,
+                'max_speed': 10,
+                'average_speed': 10,
+            },
+        )
+
+        assert segment.duration.microseconds == 0

--- a/fittrackee/workouts/utils/workouts.py
+++ b/fittrackee/workouts/utils/workouts.py
@@ -174,7 +174,7 @@ def create_segment(
         workout_uuid=workout_uuid,
         segment_id=segment_data['idx'],
     )
-    new_segment.duration = segment_data['duration']
+    new_segment.duration = _remove_microseconds(segment_data['duration'])
     new_segment.distance = segment_data['distance']
     update_workout_data(new_segment, segment_data)
     return new_segment


### PR DESCRIPTION
see #247 

Note: it fixes only next imported workouts.