### PR TITLE
Disable worker entry point

### DIFF
--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -396,7 +396,7 @@ For instance, copy and update ``.env`` file from ``.env.example`` and source the
 
 .. code-block:: bash
 
-    $ fittrackee_worker --processes 2
+    $ flask worker --processes 2
 
 .. note::
     | To start application and workers with **systemd** service, see `Deployment <installation.html#deployment>`__

--- a/fittrackee/__main__.py
+++ b/fittrackee/__main__.py
@@ -81,6 +81,14 @@ def upgrade_db() -> None:
         upgrade(directory=BASEDIR + '/migrations')
 
 
+def worker() -> None:
+    raise SystemExit(
+        "Error: this command is disabled, "
+        "it will be removed in a next version.\n"
+        "Please use flask-dramatiq CLI instead ('flask worker')."
+    )
+
+
 def main() -> None:
     options = {'bind': f'{HOST}:{PORT}', 'workers': WORKERS}
     StandaloneApplication(app, options).run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ types-redis = "^4.3"
 
 [tool.poetry.scripts]
 fittrackee = 'fittrackee.__main__:main'
-fittrackee_worker = 'flask_dramatiq:worker'
+fittrackee_worker = 'fittrackee.__main__:worker'  # disabled
 ftcli = 'fittrackee.cli:cli'
 fittrackee_set_admin = 'fittrackee.__main__:set_admin'  # deprecated
 fittrackee_upgrade_db = 'fittrackee.__main__:upgrade_db'  # deprecated


### PR DESCRIPTION
Since Flask update to 2.2.x, `fittrackee_worker` is not working anymore.

This entrypoint is now disabled, since it is just a duplicate command for `flask worker` ([flask-dramatiq CLI](https://flask-dramatiq.readthedocs.io/en/latest/cli.html)).

It will be completely removed in a next version.