### PR TITLE
CI - update actions version

### DIFF
--- a/.github/workflows/.tests-javascript.yml
+++ b/.github/workflows/.tests-javascript.yml
@@ -13,9 +13,9 @@ jobs:
   javascript:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 17.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "17.x"
       - name: Install yarn and dependencies

--- a/.github/workflows/.tests-python.yml
+++ b/.github/workflows/.tests-python.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         python-version:  [ "3.8", "3.9", "3.10", "3.11" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Poetry and Dependencies
         run: |
           python -m pip install --upgrade pip
@@ -76,7 +76,7 @@ jobs:
       matrix:
         psql-version:  [ "11", "12", "13", "14" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Poetry and Dependencies
         run: |
           python -m pip install --upgrade pip
@@ -114,7 +114,7 @@ jobs:
       EMAIL_URL: "smtp://mailhog:1025"
       REDIS_URL: "redis://redis:6379"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Poetry and Dependencies
         run: |
           python -m pip install --upgrade pip
@@ -161,7 +161,7 @@ jobs:
       HOST: "0.0.0.0"
       PORT: 5000
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update pip and install build
         run: python3 -m pip install --upgrade pip build
       - name: Create and source virtual environment


### PR DESCRIPTION
see warnings on CI:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-node@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
