### PR TITLE
CI - fix e2e tests with packaged version

### DIFF
--- a/.github/workflows/.tests-python.yml
+++ b/.github/workflows/.tests-python.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Run migrations
         run: ftcli db upgrade
       - name: Install pytest and selenium
-        run: python3 -m pip install pytest==7.4.0 pytest-selenium==4.0.1 selenium==4.9.0
+        run: python3 -m pip install pytest==7.4.0 pytest-selenium==4.0.1 selenium==4.9.0 pytest-html==3.2.0
       - name: Start application and run tests with Selenium
         run: |
           setsid nohup fittrackee >> nohup.out 2>&1 &


### PR DESCRIPTION
`pytest-html` latest version removed `py` as a dependency (see pytest-selenium/issues/313)