### PR TITLE
Pin Flask-SQLAlchemy version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2725,4 +2725,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "8455a7b70d2a966152da804dcbaa3780bb516953105ce2b73c7e2442432f3ae6"
+content-hash = "9572dd65693d4c14d05589eec5bf945c1751e67ccd0c3c53ed9c2e69ae9e0d3e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ flask-bcrypt = "^1.0"
 flask-dramatiq = "^0.6"
 flask-limiter = {version = "^3.5", extras = ["redis"]}
 flask-migrate = "^4.0"
+flask-sqlalchemy = "3.0.5"
 gpxpy = "=1.5.0"
 gunicorn = "^21.0"
 humanize = "^4.7"


### PR DESCRIPTION
see #441 

pin Flask-SQLAlchemy to 3.0.5 (latest version compatible w/ Flask 3.0 and SQLalchemy 1.4) 

Note: version 3.0.5 has already been pinned to `poetry.lock`