### PR TITLE
Build - use poetry-core instead of poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,5 +97,5 @@ combine_as_imports = true
 exclude_dirs = ["fittrackee/tests/*", "fittrackee/migrations/*"]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
See https://python-poetry.org/docs/pyproject/#poetry-and-pep-517

This would help avoid patching the repository when packaging it in nixpkgs: https://github.com/NixOS/nixpkgs/blob/e613b63475ada269627724723c19c5e8e4132dea/pkgs/servers/geospatial/fit-trackee/default.nix#L52-L53
