### PR TITLE
Update `install-python` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ install-client-dev:
 install-dev: install-client-dev install-python-dev
 
 install-python:
-	$(POETRY) install --no-dev
+	$(POETRY) install --only main
 
 install-python-dev:
 	$(POETRY) install

--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -28,7 +28,7 @@ Prerequisites
     - Redis for task queue (if email sending is enabled and for data export requests) and API rate limits
     - SMTP provider (if email sending is enabled)
     - API key from a `weather data provider <installation.html#weather-data>`__
-    - `Poetry <https://python-poetry.org>`__ (for installation from sources only)
+    - `Poetry <https://python-poetry.org>`__ 1.2+ (for installation from sources only)
     - `Node <https://nodejs.org>`__ 18+ and `Yarn <https://yarnpkg.com>`__ (for development only)
     -  Docker and Docker Compose (for development or evaluation purposes)
 


### PR DESCRIPTION
The `--no-dev` option is deprecated, since Poetry uses groups for dependencies (version [ 1.2](https://python-poetry.org/blog/announcing-poetry-1.2.0/#dependency-groups), released on August 31, 2022).

Use the `--only main` notation for `make install-python`.