### PR TITLE
CLI - init language preference on user creation

### DIFF
--- a/docsrc/source/cli.rst
+++ b/docsrc/source/cli.rst
@@ -118,6 +118,8 @@ Create a user account.
      - User email (mandatory).
    * - ``--password PASSWORD``
      - User password (if not provided, a random password is generated).
+   * - ``--lang LANGUAGE``
+     - User preference for interface language (two-letter codes, ISO 639-1). If not provided or not supported, it falls back to English ('en').
 
 
 

--- a/fittrackee/config.py
+++ b/fittrackee/config.py
@@ -17,6 +17,20 @@ XDIST_WORKER = (
     if os.getenv('PYTEST_XDIST_WORKER')
     else ''
 )
+SUPPORTED_LANGUAGES = [
+    'cs',  # Czech
+    'de',  # German
+    'en',  # English
+    'es',  # Spanish
+    'eu',  # Basque
+    'fr',  # French
+    'gl',  # Galician
+    'it',  # Italian
+    'nb',  # Norwegian Bokmål
+    'nl',  # Dutch
+    'pl',  # Polish
+    'pt',  # Portuguese
+]
 
 
 class BaseConfig:
@@ -57,20 +71,7 @@ class BaseConfig:
     TRANSLATIONS_FOLDER = os.path.join(
         current_app.root_path, 'emails/translations'
     )
-    LANGUAGES = [
-        'en',
-        'fr',
-        'de',
-        'it',
-        'nb',
-        'nl',
-        'es',
-        'gl',
-        'pl',
-        'eu',
-        'cs',
-        'pt',
-    ]
+    LANGUAGES = SUPPORTED_LANGUAGES
     OAUTH2_TOKEN_EXPIRES_IN = {
         'authorization_code': 864000,  # 10 days
         'refresh_token': 864000,  # 10 days

--- a/fittrackee/tests/users/test_users_commands.py
+++ b/fittrackee/tests/users/test_users_commands.py
@@ -74,7 +74,7 @@ class TestCliUserCreate:
             ],
         )
 
-        assert result.output == f"User '{username}' created.\n"
+        assert f"User '{username}' created.\n" in result.output
 
     def test_it_displays_password_when_password_is_not_provided(
         self,
@@ -90,9 +90,75 @@ class TestCliUserCreate:
                 ["create", username, "--email", random_email()],
             )
 
-        assert result.output == (
-            f"User '{username}' created.\n"
-            f"The user password is: {password}\n"
+        assert f"The user password is: {password}\n" in result.output
+
+    def test_it_creates_user_with_default_language(
+        self, app: Flask, user_1: User
+    ) -> None:
+        username = random_string()
+        runner = CliRunner()
+
+        result = runner.invoke(
+            users_cli,
+            ["create", username, "--email", random_email()],
+        )
+
+        user = User.query.filter_by(username=username).first()
+        assert user.language == "en"
+        assert (
+            'The user preference for interface language is: en'
+            in result.output
+        )
+
+    def test_it_creates_user_with_provided_language(
+        self, app: Flask, user_1: User
+    ) -> None:
+        username = random_string()
+        language = "fr"
+        runner = CliRunner()
+
+        result = runner.invoke(
+            users_cli,
+            [
+                "create",
+                username,
+                "--email",
+                random_email(),
+                "--lang",
+                language,
+            ],
+        )
+
+        user = User.query.filter_by(username=username).first()
+        assert user.language == language
+        assert (
+            f'The user preference for interface language is: {language}'
+            not in result.output
+        )
+
+    def test_it_creates_user_with_default_language_when_not_supported(
+        self, app: Flask, user_1: User
+    ) -> None:
+        username = random_string()
+        runner = CliRunner()
+
+        result = runner.invoke(
+            users_cli,
+            [
+                "create",
+                username,
+                "--email",
+                random_email(),
+                "--lang",
+                "invalid",
+            ],
+        )
+
+        user = User.query.filter_by(username=username).first()
+        assert user.language == "en"
+        assert (
+            'The user preference for interface language is: en'
+            in result.output
         )
 
 

--- a/fittrackee/users/commands.py
+++ b/fittrackee/users/commands.py
@@ -6,12 +6,14 @@ from humanize import naturalsize
 
 from fittrackee import db
 from fittrackee.cli.app import app
+from fittrackee.config import SUPPORTED_LANGUAGES
 from fittrackee.users.exceptions import UserNotFoundException
 from fittrackee.users.export_data import (
     clean_user_data_export,
     generate_user_data_archives,
 )
 from fittrackee.users.utils.admin import UserManagerService
+from fittrackee.users.utils.language import get_language
 from fittrackee.users.utils.token import clean_blacklisted_tokens
 
 handler = logging.StreamHandler()
@@ -34,7 +36,18 @@ def users_cli() -> None:
     type=str,
     help='User password. If not provided, a random password is generated.',
 )
-def create_user(username: str, email: str, password: Optional[str]) -> None:
+@click.option(
+    '--lang',
+    type=str,
+    help=(
+        'User preference for interface language (two-letter codes, ISO 639-1).'
+        ' If not provided or not supported, it falls back to English (\'en\').'
+        f' Supported languages: {", ".join(SUPPORTED_LANGUAGES)}.'
+    ),
+)
+def create_user(
+    username: str, email: str, password: Optional[str], lang: Optional[str]
+) -> None:
     """Create an active user account."""
     with app.app_context():
         try:
@@ -42,12 +55,20 @@ def create_user(username: str, email: str, password: Optional[str]) -> None:
             user, user_password = user_manager_service.create_user(
                 email=email, password=password, check_email=True
             )
-            db.session.add(user)
-            db.session.commit()
-            user_manager_service.update(activate=True)
-            click.echo(f"User '{username}' created.")
-            if not password:
-                click.echo(f"The user password is: {user_password}")
+            if user:
+                db.session.add(user)
+                user_language = get_language(lang)
+                user.language = user_language
+                db.session.commit()
+                user_manager_service.update(activate=True)
+                click.echo(f"User '{username}' created.")
+                if lang != user_language:
+                    click.echo(
+                        "The user preference for interface language "
+                        f"is: {user_language}"
+                    )
+                if not password:
+                    click.echo(f"The user password is: {user_password}")
         except Exception as e:
             click.echo(f'Error(s) occurred:\n{e}', err=True)
 


### PR DESCRIPTION
Add an option to the Users CLI to initialize user preference on user creation (default value: 'en' (English), as for [registration through API](https://samr1.github.io/FitTrackee/en/api/auth.html#post--api-auth-register)).

Example:
```shell
$ ftcli users create Sam --email sam@example.com --lang fr
``` 
