### PR TITLE
Simplify docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ RUN pip install poetry
 RUN . $VIRTUAL_ENV/bin/activate && poetry install --no-interaction --quiet
 
 # run fittrackee server
-CMD flask run --with-threads -h 0.0.0.0
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+COPY ./docker/set-admin.sh /usr/bin/set-admin
+RUN chmod +x /usr/bin/set-admin && chmod +x /docker-entrypoint.sh
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -44,98 +44,98 @@ clean-install: clean
 
 ## Docker commands for evaluation purposes
 docker-bandit:
-	docker-compose -f docker-compose-dev.yml exec fittrackee bandit -r fittrackee -c pyproject.toml
+	docker compose -f docker-compose-dev.yml exec fittrackee bandit -r fittrackee -c pyproject.toml
 
 docker-build:
-	docker-compose -f docker-compose-dev.yml build fittrackee
+	docker compose -f docker-compose-dev.yml build fittrackee
 
 docker-build-all: docker-build docker-build-client
 
 docker-build-client:
-	docker-compose -f docker-compose-dev.yml build fittrackee_client
+	docker compose -f docker-compose-dev.yml build fittrackee_client
 
 docker-check-all: docker-bandit docker-lint-all docker-type-check docker-test-client docker-test-python
 
 docker-downgrade-db:
-	docker-compose -f docker-compose-dev.yml exec fittrackee flask db downgrade --directory $(DOCKER_MIGRATIONS)
+	docker compose -f docker-compose-dev.yml exec fittrackee flask db downgrade --directory $(DOCKER_MIGRATIONS)
 
 docker-init: docker-run docker-init-db docker-restart docker-run-workers
 
 docker-init-db:
-	docker-compose -f docker-compose-dev.yml exec fittrackee docker/init-database.sh
+	docker compose -f docker-compose-dev.yml exec fittrackee docker/init-database.sh
 
 docker-lint-all: docker-lint-client docker-lint-python
 
 docker-lint-client:
-	docker-compose -f docker-compose-dev.yml up -d fittrackee_client
-	docker-compose -f docker-compose-dev.yml exec fittrackee_client $(NPM) lint
-	docker-compose -f docker-compose-dev.yml exec fittrackee_client $(NPM) type-check
+	docker compose -f docker-compose-dev.yml up -d fittrackee_client
+	docker compose -f docker-compose-dev.yml exec fittrackee_client $(NPM) lint
+	docker compose -f docker-compose-dev.yml exec fittrackee_client $(NPM) type-check
 
 docker-lint-python: docker-run
-	docker-compose -f docker-compose-dev.yml exec fittrackee docker/lint-python.sh
+	docker compose -f docker-compose-dev.yml exec fittrackee docker/lint-python.sh
 
 docker-logs:
-	docker-compose -f docker-compose-dev.yml logs --follow
+	docker compose -f docker-compose-dev.yml logs --follow
 
 docker-migrate-db:
-	docker-compose -f docker-compose-dev.yml exec fittrackee flask db migrate --directory $(DOCKER_MIGRATIONS)
+	docker compose -f docker-compose-dev.yml exec fittrackee flask db migrate --directory $(DOCKER_MIGRATIONS)
 
 docker-rebuild:
-	docker-compose -f docker-compose-dev.yml build --no-cache
+	docker compose -f docker-compose-dev.yml build --no-cache
 
 docker-restart:
-	docker-compose -f docker-compose-dev.yml restart fittrackee
-	docker-compose -f docker-compose-dev.yml exec -d fittrackee docker/run-workers.sh
+	docker compose -f docker-compose-dev.yml restart fittrackee
+	docker compose -f docker-compose-dev.yml exec -d fittrackee docker/run-workers.sh
 
 docker-revision:
-	docker-compose -f docker-compose-dev.yml exec fittrackee flask db revision --directory $(DOCKER_MIGRATIONS) --message $(MIGRATION_MESSAGE)
+	docker compose -f docker-compose-dev.yml exec fittrackee flask db revision --directory $(DOCKER_MIGRATIONS) --message $(MIGRATION_MESSAGE)
 
 docker-run-all: docker-run docker-run-workers
 
 docker-run:
-	docker-compose -f docker-compose-dev.yml up -d fittrackee
+	docker compose -f docker-compose-dev.yml up -d fittrackee
 
 docker-run-workers:
-	docker-compose -f docker-compose-dev.yml exec -d fittrackee docker/run-workers.sh
+	docker compose -f docker-compose-dev.yml exec -d fittrackee docker/run-workers.sh
 
 docker-serve-client:
-	docker-compose -f docker-compose-dev.yml up -d fittrackee_client
-	docker-compose -f docker-compose-dev.yml exec fittrackee_client $(NPM) dev
+	docker compose -f docker-compose-dev.yml up -d fittrackee_client
+	docker compose -f docker-compose-dev.yml exec fittrackee_client $(NPM) dev
 
 docker-set-admin:
-	docker-compose -f docker-compose-dev.yml exec fittrackee docker/set-admin.sh $(USERNAME)
+	docker compose -f docker-compose-dev.yml exec fittrackee docker/set-admin.sh $(USERNAME)
 
 docker-shell:
-	docker-compose -f docker-compose-dev.yml exec fittrackee docker/shell.sh
+	docker compose -f docker-compose-dev.yml exec fittrackee docker/shell.sh
 
 docker-stop:
-	docker-compose -f docker-compose-dev.yml stop
+	docker compose -f docker-compose-dev.yml stop
 
 docker-test-client:
-	docker-compose -f docker-compose-dev.yml up -d fittrackee_client
-	docker-compose -f docker-compose-dev.yml exec fittrackee_client $(NPM) test:unit run
+	docker compose -f docker-compose-dev.yml up -d fittrackee_client
+	docker compose -f docker-compose-dev.yml exec fittrackee_client $(NPM) test:unit run
 
 docker-test-client-watch:
-	docker-compose -f docker-compose-dev.yml up -d fittrackee_client
-	docker-compose -f docker-compose-dev.yml exec fittrackee_client $(NPM) test:unit watch
+	docker compose -f docker-compose-dev.yml up -d fittrackee_client
+	docker compose -f docker-compose-dev.yml exec fittrackee_client $(NPM) test:unit watch
 
 # needs a running application
 docker-test-e2e: docker-run
-	docker-compose -f docker-compose-dev.yml up -d selenium
-	docker-compose -f docker-compose-dev.yml exec fittrackee docker/test-e2e.sh $(PYTEST_ARGS)
+	docker compose -f docker-compose-dev.yml up -d selenium
+	docker compose -f docker-compose-dev.yml exec fittrackee docker/test-e2e.sh $(PYTEST_ARGS)
 
 docker-test-python: docker-run
-	docker-compose -f docker-compose-dev.yml exec fittrackee docker/test-python.sh $(PYTEST_ARGS)
+	docker compose -f docker-compose-dev.yml exec fittrackee docker/test-python.sh $(PYTEST_ARGS)
 
 docker-type-check:
 	echo 'Running mypy in docker...'
-	docker-compose -f docker-compose-dev.yml exec fittrackee mypy fittrackee
+	docker compose -f docker-compose-dev.yml exec fittrackee mypy fittrackee
 
 docker-up:
-	docker-compose -f docker-compose-dev.yml up fittrackee
+	docker compose -f docker-compose-dev.yml up fittrackee
 
 docker-upgrade-db:
-	docker-compose -f docker-compose-dev.yml exec fittrackee ftcli db upgrade
+	docker compose -f docker-compose-dev.yml exec fittrackee ftcli db upgrade
 
 downgrade-db:
 	$(FLASK) db downgrade --directory $(MIGRATIONS)

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,3 +1,0 @@
-FROM postgres:13
-
-COPY create.sql /docker-entrypoint-initdb.d

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,10 +1,7 @@
-version: '3.8'
-
 services:
-
   fittrackee-db:
     container_name: fittrackee-db
-    build: ./db
+    image: postgres:13
     ports:
       - "5435:5432"
     environment:
@@ -12,9 +9,13 @@ services:
       - POSTGRES_PASSWORD=postgres
     volumes:
       - ./data/db:/var/lib/postgresql/data
-    networks:
-      - fittrackee-net
-  
+      - ./db/create.sql:/docker-entrypoint-initdb.d/create.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
+
   fittrackee:
     container_name: fittrackee
     build: .
@@ -23,14 +24,15 @@ services:
     env_file:
       - .env
     depends_on:
-      - fittrackee-db
-      - redis
-      - mail
+      fittrackee-db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      mail:
+        condition: service_started
     volumes:
       - .:/usr/src/app
       - ./data/uploads:/usr/src/app/uploads
-    networks:
-      - fittrackee-net
 
   fittrackee_client:
     container_name: fittrackee_client
@@ -56,8 +58,6 @@ services:
     hostname: redis
     ports:
       - "6379:6379"
-    networks:
-      - fittrackee-net
 
   mail:
     container_name: fittrackee-mailhog
@@ -65,14 +65,9 @@ services:
     ports:
       - "1025:1025"
       - "8025:8025"
-    networks:
-      - fittrackee-net
 
   selenium:
     image: selenium/standalone-firefox:latest
     hostname: selenium
     privileged: true
     shm_size: 2g
-
-networks:
-  fittrackee-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,73 @@
+services:
+  fittrackee-db:
+    container_name: fittrackee-db
+    image: postgres:13
+    ports:
+      - "5435:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    volumes:
+      - ./data/db:/var/lib/postgresql/data
+      - ./db/create.sql:/docker-entrypoint-initdb.d/create.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 15s
+      retries: 3
+
+  fittrackee:
+    container_name: fittrackee
+    build: .
+    ports:
+      - "5000:5000"
+    env_file:
+      - .env
+    depends_on:
+      fittrackee-db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      mail:
+        condition: service_started
+    volumes:
+      - .:/usr/src/app
+      - ./data/uploads:/usr/src/app/uploads
+
+  fittrackee_client:
+    container_name: fittrackee_client
+    environment:
+      - NODE_ENV=development
+      - VITE_APP_API_URL=http://localhost:5000
+    build:
+      context: ./fittrackee_client
+    volumes:
+      - ./fittrackee_client:/usr/src/app
+      - /usr/src/app/node_modules
+    depends_on:
+      - fittrackee
+    ports:
+      - "3000:3000"
+    stdin_open: true
+    tty: true
+    command: /bin/sh
+
+  redis:
+    container_name: fittrackee-redis
+    image: "redis:latest"
+    hostname: redis
+    ports:
+      - "6379:6379"
+
+  mail:
+    container_name: fittrackee-mailhog
+    image: "mailhog/mailhog"
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+
+  selenium:
+    image: selenium/standalone-firefox:latest
+    hostname: selenium
+    privileged: true
+    shm_size: 2g

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Change to the application directory
+cd /usr/src/app || exit 1
+
+# Check if the .env file exists and source it
+if [[ -f .env ]]; then
+    source .env
+else
+    echo ".env file not found!"
+    exit 1
+fi
+
+# Wait for postgres
+#sleep 20
+
+# Init database
+echo "Initializing database..."
+ftcli db upgrade || { echo "Failed to upgrade database!"; exit 1; }
+
+# Run workers
+echo "Initializing workers..."
+flask worker --processes="${WORKERS_PROCESSES:-1}" >> dramatiq.log 2>&1 &
+
+# Run app
+echo "Initializing app..."
+exec flask run --with-threads --host=0.0.0.0

--- a/docker/init-database.sh
+++ b/docker/init-database.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-cd /usr/src/app
-
-source .env
-
-ftcli db drop
-ftcli db upgrade

--- a/docker/run-workers.sh
+++ b/docker/run-workers.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-cd /usr/src/app
-
-source .env
-
-flask worker --processes=$WORKERS_PROCESSES >> dramatiq.log  2>&1


### PR DESCRIPTION
This PR makes the docker deployment much simpler. I think it is important for users to have to run the minimum commands, so this PR simplifies the deploy process to:

1. Clone the repo
2. Run `docker compose up -d`

If you have any questions or suggestions, please make me aware.

## Use of docker-entrypoint.sh and integrate set-admin command

I moved all the init actions to a `docker-entrypoint.sh` file that is set as `ENTRYPOINT` and runs on startup of the container (check Dockerfile). Since the startup process is now part of the entrypoint, I have removed the `docker/init-database.sh` and `docker/run-workers.sh` files. These should also be cleaned up from the `Makefile`.

Also the set admin command is now part of the path and can be easily called with:

```
docker compose exec -it fittrackee set-admin USERNAME="myuser"
```

## Remove unnecessary postgress image build

I removed the `Dockerfile` and build form the postgres service, it now mounts the `create.sql` file by default on the init folder, which is only run if db is not initialized. The image is the official one from dockerhub.

## Add postgress healthcheck and conditions on depends

The postgres has a healthcheck and the main fittrackee container waits for it to be healthy, it also waits for other containers to be started. This is achieved with the `condition` on the `depends_on` services.

## update to use `docker compose` command

`docker-compose` is the old syntax, which has now been updated and integrated to `docker compose` command, this latest version is better and has more options available. See: https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose

## remove unnecessary network

Docker compose creates a default network, so there is no need to declare a network.