### PR TITLE
CLI - fix limit for user data export cleanup

### DIFF
--- a/fittrackee/tests/users/test_users_export_data.py
+++ b/fittrackee/tests/users/test_users_export_data.py
@@ -588,7 +588,7 @@ class UserDataExportTestCase:
     ) -> UserDataExport:
         user_data_export = UserDataExport(
             user_id=user.id,
-            created_at=datetime.now() - timedelta(days=days),
+            created_at=datetime.utcnow() - timedelta(days=days),
         )
         db.session.add(user_data_export)
         user_data_export.completed = completed

--- a/fittrackee/users/export_data.py
+++ b/fittrackee/users/export_data.py
@@ -149,7 +149,7 @@ def export_user_data(export_request_id: int) -> None:
 
 def clean_user_data_export(days: int) -> Dict:
     counts = {"deleted_requests": 0, "deleted_archives": 0, "freed_space": 0}
-    limit = datetime.now() - timedelta(days=days)
+    limit = datetime.utcnow() - timedelta(days=days)
     export_requests = UserDataExport.query.filter(
         UserDataExport.created_at < limit,
         UserDataExport.completed == True,  # noqa


### PR DESCRIPTION
`datetime.now()` was used instead of `datetime.utcnow()` to filter user data export (`UserDataExport.created_at` is initaliazed with  `datetime.utcnow()`).

**Note**: [`datetime.utcnow()` is now deprecated](https://docs.python.org/3/whatsnew/3.12.html#deprecated). It will be replaced in a next version of **FitTrackee**. 