### PR TITLE
Fix email sending by adding 'Message-ID'

### DIFF
--- a/fittrackee/emails/email.py
+++ b/fittrackee/emails/email.py
@@ -1,3 +1,4 @@
+import email.utils as email_utils
 import logging
 import smtplib
 import ssl
@@ -32,6 +33,9 @@ class EmailMessage:
         message['Subject'] = self.subject
         message['From'] = self.sender
         message['To'] = self.recipient
+        message['Message-ID'] = email_utils.make_msgid(
+            domain=self.sender.split("@")[-1]
+        )
         part1 = MIMEText(self.text, 'plain')
         part2 = MIMEText(self.html, 'html')
         message.attach(part1)


### PR DESCRIPTION
Some SMTP providers may reject emails as spam due to missing `Message-ID` header : 

```python
  File "/usr/lib/python3.12/smtplib.py", line 897, in sendmail
    raise SMTPDataError(code, resp)
smtplib.SMTPDataError: (550, b'5.7.1 Spam Detected - Mail Rejected.  Please see our policy at: xxx')
```