### PR TITLE
api - get workouts list with equipment

### DIFF
--- a/fittrackee/tests/workouts/test_workouts_api_0_get_workouts.py
+++ b/fittrackee/tests/workouts/test_workouts_api_0_get_workouts.py
@@ -1400,3 +1400,53 @@ class TestGetWorkoutsWithFiltersAndPagination(WorkoutApiTestCaseMixin):
             'pages': 2,
             'total': 7,
         }
+
+
+class TestGetWorkoutsWithEquipments(WorkoutApiTestCaseMixin):
+    @pytest.mark.parametrize('input_params', ['', '?return_equipments=false'])
+    def test_it_returns_workout_without_equipments(
+        self,
+        app: Flask,
+        user_1: User,
+        sport_1_cycling: Sport,
+        workout_cycling_user_1: Workout,
+        equipment_bike_user_1: Equipment,
+        input_params: str,
+    ) -> None:
+        workout_cycling_user_1.equipments = [equipment_bike_user_1]
+        client, auth_token = self.get_test_client_and_auth_token(
+            app, user_1.email
+        )
+
+        response = client.get(
+            f'/api/workouts{input_params}',
+            headers=dict(Authorization=f'Bearer {auth_token}'),
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data.decode())
+        assert data['data']['workouts'][0]['equipments'] == []
+
+    def test_it_returns_workout_with_equipments_when_flag_is_true(
+        self,
+        app: Flask,
+        user_1: User,
+        sport_1_cycling: Sport,
+        workout_cycling_user_1: Workout,
+        equipment_bike_user_1: Equipment,
+    ) -> None:
+        workout_cycling_user_1.equipments = [equipment_bike_user_1]
+        client, auth_token = self.get_test_client_and_auth_token(
+            app, user_1.email
+        )
+
+        response = client.get(
+            '/api/workouts?return_equipments=true',
+            headers=dict(Authorization=f'Bearer {auth_token}'),
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data.decode())
+        assert data['data']['workouts'][0]['equipments'] == [
+            jsonify_dict(equipment_bike_user_1.serialize())
+        ]

--- a/fittrackee/workouts/workouts.py
+++ b/fittrackee/workouts/workouts.py
@@ -240,6 +240,11 @@ def get_workouts(auth_user: User) -> Union[Dict, HttpResponse]:
                          notes matching is case-insensitive
     :query string description: any part of the workout description;
                          description matching is case-insensitive
+    :query string return_equipments: return workouts with equipment
+                         (by default, equipment is not returned).
+                         **Note**: It's not a filter.
+                         **Warning**: Needed for 3rd-party applications
+                         updating equipments.
 
 
     :reqheader Authorization: OAuth 2.0 Bearer Token
@@ -375,11 +380,18 @@ def get_workouts(auth_user: User) -> Union[Dict, HttpResponse]:
         )
 
         workouts = workouts_pagination.items
+        with_equipments = (
+            params.get('return_equipments', 'false').lower() == 'true'
+        )
         return {
             'status': 'success',
             'data': {
                 'workouts': [
-                    workout.serialize(user=auth_user, params=params)
+                    workout.serialize(
+                        user=auth_user,
+                        params=params,
+                        with_equipments=with_equipments,
+                    )
                     for workout in workouts
                 ]
             },


### PR DESCRIPTION
To avoid fetching unnecessary data when displaying workouts list, equipment is not returned since 0.9.0b1.
This behavior prevents 3rd party apps like this [script](https://codeberg.org/SamR1/workouts-equipments-updater) to update workouts equipment.

This PR add a parameter to return workouts with equipment when provided.