### PR TITLE
Publish package on PyPI using GitHub Actions workflow

### DIFF
--- a/.github/workflows/.e2e-tests.yml
+++ b/.github/workflows/.e2e-tests.yml
@@ -1,0 +1,85 @@
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+        default: 3.13
+      postgres-version:
+        type: string
+        default: 17
+      previous-version:
+        type: boolean
+        default: false
+
+jobs:
+  test_package:
+    runs-on: ubuntu-latest
+    container: python:${{ inputs.python-version }}
+    services:
+      postgres:
+        image: postgres:${{ inputs.postgres-version }}
+        env:
+          POSTGRES_DB: fittrackee_test
+          POSTGRES_USER: fittrackee
+          POSTGRES_PASSWORD: fittrackee
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      selenium:
+        image: selenium/standalone-firefox
+      mailhog:
+        image: mailhog/mailhog:latest
+      redis:
+        image: redis:latest
+    env:
+      APP_SETTINGS: fittrackee.config.End2EndTestingConfig
+      DATABASE_TEST_URL: "postgresql://fittrackee:fittrackee@postgres:5432/fittrackee_test"
+      FLASK_APP: fittrackee
+      EMAIL_URL: "smtp://mailhog:1025"
+      REDIS_URL: "redis://redis:6379"
+      HOST: "0.0.0.0"
+      PORT: 5000
+      SENDER_EMAIL: fittrackee@example.com
+    steps:
+
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install previous version of FitTrackee from PyPI
+        if: inputs.python-version.previous-version
+        run: python3 -m pip install fittrackee
+
+      - name: Run migrations
+        if: inputs.python-version.previous-version
+        run: ftcli db upgrade
+
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create and source virtual environment
+        run: | 
+          python3 -m venv .venv 
+          . .venv/bin/activate
+
+      - name: Install fittrackee package
+        run: python3 -m pip install dist/fittrackee-$(cat VERSION).tar.gz
+
+      - name: Run migrations
+        run: ftcli db upgrade
+
+      - name: Install pytest and selenium
+        run: python3 -m pip install pytest==8.2.0 pytest-selenium==4.1.0 selenium==4.20.0 pytest-html==4.1.1
+
+      - name: Start application and run tests with Selenium
+        run: |
+          setsid nohup fittrackee >> nohup.out 2>&1 &
+          export TEST_APP_URL=http://$(hostname --ip-address):5000
+          sleep 5
+          nohup flask worker --processes=1 >> nohup.out 2>&1 &
+          pytest e2e --driver Remote --capability browserName firefox --selenium-host selenium --selenium-port 4444 --maxfail=1

--- a/.github/workflows/.tests-python.yml
+++ b/.github/workflows/.tests-python.yml
@@ -34,24 +34,31 @@ jobs:
       matrix:
         python-version:  [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
+
       - uses: actions/checkout@v4
+
       - name: Install Poetry and Dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --quiet poetry
           poetry config virtualenvs.create false
           poetry install --no-interaction --quiet
+
       - name: Create test databases
         run: python db/create_ci_test_db.py
+
       - name: Bandit
         if: matrix.python-version == '3.13'
         run: bandit -r fittrackee -c pyproject.toml
+
       - name: Lint
         if: matrix.python-version == '3.13'
         run: ruff check fittrackee e2e
+
       - name: Mypy
         if: matrix.python-version == '3.13'
         run: mypy fittrackee
+
       - name: Pytest
         run: pytest fittrackee -n auto --maxprocesses=2  -p no:warnings --cov fittrackee --cov-report term-missing --maxfail=1
 
@@ -74,15 +81,19 @@ jobs:
       matrix:
         psql-version:  [ "12", "13", "14", "15", "16" ]
     steps:
+
       - uses: actions/checkout@v4
+
       - name: Install Poetry and Dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --quiet poetry
           poetry config virtualenvs.create false
           poetry install --no-interaction --quiet
+
       - name: Create test databases
         run: python db/create_ci_test_db.py
+
       - name: Pytest
         run: pytest fittrackee -n auto --maxprocesses=2 -p no:warnings --cov fittrackee --cov-report term-missing --maxfail=1
 
@@ -115,15 +126,19 @@ jobs:
       EMAIL_URL: "smtp://mailhog:1025"
       REDIS_URL: "redis://redis:6379"
     steps:
+
       - uses: actions/checkout@v4
+
       - name: Install Poetry and Dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --quiet poetry
           poetry config virtualenvs.create false
           poetry install --no-interaction --quiet
+
       - name: Run migrations
         run: flask db upgrade --directory fittrackee/migrations
+
       - name: Start application and run tests with Selenium
         run: |
           setsid nohup flask run --with-threads -h 0.0.0.0 -p 5000 >> nohup.out 2>&1 &
@@ -191,3 +206,66 @@ jobs:
     uses: ./.github/workflows/.e2e-tests.yml
     with:
       previous-version: true
+
+  publish-to-pypi:
+    if: github.repository == 'SamR1/FitTrackee' && startsWith(github.ref, 'refs/tags/v')
+    name: Publish Python distribution to PyPI
+    needs: ["end2end", "end2end_package", "end2end_package_update"]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/fittrackee
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    if: github.repository == 'SamR1/FitTrackee' && startsWith(github.ref, 'refs/tags/v')
+    name: Upload distribution to GitHub Release
+    needs: ["publish-to-pypi"]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+
+    - name: Create GitHub draft release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        "$GITHUB_REF_NAME"
+        --repo "$GITHUB_REPOSITORY"
+        --draft
+        --notes "wip"
+
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release upload
+        "$GITHUB_REF_NAME" dist/**
+        --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/.tests-python.yml
+++ b/.github/workflows/.tests-python.yml
@@ -17,12 +17,12 @@ env:
 jobs:
   python:
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.fork }}
-    name: python ${{ matrix.python-version }} (postgresql 15)
+    name: python ${{ matrix.python-version }} (postgresql 17)
     runs-on: ubuntu-latest
     container: python:${{ matrix.python-version }}
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -44,22 +44,22 @@ jobs:
       - name: Create test databases
         run: python db/create_ci_test_db.py
       - name: Bandit
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.13'
         run: bandit -r fittrackee -c pyproject.toml
       - name: Lint
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.13'
         run: ruff check fittrackee e2e
       - name: Mypy
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.13'
         run: mypy fittrackee
       - name: Pytest
         run: pytest fittrackee -n auto --maxprocesses=2  -p no:warnings --cov fittrackee --cov-report term-missing --maxfail=1
 
   postgresql:
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.fork }}
-    name: postgresql ${{ matrix.psql-version }} (python 3.11)
+    name: postgresql ${{ matrix.psql-version }} (python 3.13)
     runs-on: ubuntu-latest
-    container: python:3.11
+    container: python:3.13
     services:
       postgres:
         image: postgres:${{ matrix.psql-version }}
@@ -72,7 +72,7 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        psql-version:  [ "12", "13", "14", "16", "17" ]
+        psql-version:  [ "12", "13", "14", "15", "16" ]
     steps:
       - uses: actions/checkout@v4
       - name: Install Poetry and Dependencies
@@ -88,13 +88,13 @@ jobs:
 
   end2end:
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.fork }}
-    name: e2e tests
+    name: e2e tests with sources
     runs-on: ubuntu-latest
     needs: ["python"]
-    container: python:3.11
+    container: python:3.13
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_DB: fittrackee_test
           POSTGRES_USER: fittrackee
@@ -132,114 +132,62 @@ jobs:
           nohup flask worker --processes=1 >> nohup.out 2>&1 &
           pytest e2e --driver Remote --capability browserName firefox --selenium-host selenium --selenium-port 4444 --maxfail=1
 
+  build_package:
+    needs: ["python"]
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Use Node.js 23.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 23.x
+
+    - name: Install yarn and dependencies
+      working-directory: fittrackee_client
+      run: |
+        npm install --global yarn
+        yarn install
+
+    - name: Build dist files
+      working-directory: fittrackee_client
+      run: yarn build
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+
+    - name: Install poetry
+      run: >-
+        python3 -m
+        pip install
+        poetry
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      run: poetry build
+
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+        retention-days: 5
+
   end2end_package:
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.fork }}
     name: e2e tests with package
-    runs-on: ubuntu-latest
-    needs: ["python"]
-    container: python:3.11
-    services:
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_DB: fittrackee_test
-          POSTGRES_USER: fittrackee
-          POSTGRES_PASSWORD: fittrackee
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      selenium:
-        image: selenium/standalone-firefox
-      mailhog:
-        image: mailhog/mailhog:latest
-      redis:
-        image: redis:latest
-    env:
-      APP_SETTINGS: fittrackee.config.End2EndTestingConfig
-      EMAIL_URL: "smtp://mailhog:1025"
-      REDIS_URL: "redis://redis:6379"
-      HOST: "0.0.0.0"
-      PORT: 5000
-    steps:
-      - uses: actions/checkout@v4
-      - name: Update pip and install build
-        run: python3 -m pip install --upgrade pip build
-      - name: Create and source virtual environment
-        run: | 
-          python3 -m venv .venv 
-          . .venv/bin/activate
-      - name: Build fittrackee package
-        run: python3 -m build
-      - name: Install fittrackee package
-        run: python3 -m pip install dist/fittrackee-$(cat VERSION).tar.gz
-      - name: Run migrations
-        run: ftcli db upgrade
-      - name: Install pytest and selenium
-        run: python3 -m pip install pytest==8.2.0 pytest-selenium==4.1.0 selenium==4.20.0 pytest-html==4.1.1
-      - name: Start application and run tests with Selenium
-        run: |
-          setsid nohup fittrackee >> nohup.out 2>&1 &
-          export TEST_APP_URL=http://$(hostname --ip-address):5000
-          sleep 5
-          nohup flask worker --processes=1 >> nohup.out 2>&1 &
-          pytest e2e --driver Remote --capability browserName firefox --selenium-host selenium --selenium-port 4444 --maxfail=1
+    needs: ["build_package"]
+    uses: ./.github/workflows/.e2e-tests.yml
 
   end2end_package_update:
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.fork }}
-    name: e2e tests after update
-    runs-on: ubuntu-latest
-    needs: ["python"]
-    container: python:3.11
-    services:
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_DB: fittrackee_test
-          POSTGRES_USER: fittrackee
-          POSTGRES_PASSWORD: fittrackee
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      selenium:
-        image: selenium/standalone-firefox
-      mailhog:
-        image: mailhog/mailhog:latest
-      redis:
-        image: redis:latest
-    env:
-      APP_SETTINGS: fittrackee.config.End2EndTestingConfig
-      EMAIL_URL: "smtp://mailhog:1025"
-      REDIS_URL: "redis://redis:6379"
-      HOST: "0.0.0.0"
-      PORT: 5000
-    steps:
-      - uses: actions/checkout@v4
-      - name: Update pip and install build
-        run: python3 -m pip install --upgrade pip build
-      - name: Create and source virtual environment
-        run: | 
-          python3 -m venv .venv 
-          . .venv/bin/activate
-      - name: Install previous version of fittrackee from PyPI
-        run: python3 -m pip install fittrackee
-      - name: Run migrations
-        run: ftcli db upgrade
-      - name: Build fittrackee package
-        run: python3 -m build
-      - name: Install fittrackee package to update instance
-        run: python3 -m pip install dist/fittrackee-$(cat VERSION).tar.gz
-      - name: Run migrations to update database
-        run: ftcli db upgrade
-      - name: Install pytest and selenium
-        run: python3 -m pip install pytest==8.2.0 pytest-selenium==4.1.0 selenium==4.20.0 pytest-html==4.1.1
-      - name: Start application and run tests with Selenium
-        run: |
-          setsid nohup fittrackee >> nohup.out 2>&1 &
-          export TEST_APP_URL=http://$(hostname --ip-address):5000
-          sleep 5
-          nohup flask worker --processes=1 >> nohup.out 2>&1 &
-          pytest e2e --driver Remote --capability browserName firefox --selenium-host selenium --selenium-port 4444 --maxfail=1
+    name: e2e tests after FitTrackee update
+    needs: ["build_package"]
+    uses: ./.github/workflows/.e2e-tests.yml
+    with:
+      previous-version: true


### PR DESCRIPTION
Add jobs to publish Python distribution on PyPI and initiate GitHub draft release when a release tag is pushed.

source: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
