### PR TITLE
CLI - create user with provided role

### DIFF
--- a/docsrc/source/cli.rst
+++ b/docsrc/source/cli.rst
@@ -98,6 +98,7 @@ Remove blacklisted tokens expired for more than provided number of days.
 """"""""""""""""""""""
 .. versionadded:: 0.7.15
 .. versionchanged:: 0.8.4  User preference for interface language is added.
+.. versionchanged:: 0.9.0  Role is added.
 
 Create a user account.
 
@@ -121,6 +122,8 @@ Create a user account.
      - User password (if not provided, a random password is generated).
    * - ``--lang LANGUAGE``
      - User preference for interface language (two-letter code, ISO 639-1). If not provided or not supported, it falls back to English ('en').
+   * - ``--role [owner|admin|moderator|user]``
+     - User role (default: 'user').
 
 
 
@@ -160,7 +163,7 @@ Modify a user account (role, active status, email and password).
      - Username.
    * - ``--set-admin BOOLEAN``
      - [DEPRECATED] Add/remove admin rights (when adding admin rights, it also activates user account if not active).
-   * - ``--set-role ROLE``
+   * - ``--set-role [owner|admin|moderator|user]``
      - Set user role (when setting 'moderator', 'admin' and 'owner' role, it also activates user account if not active).
    * - ``--activate``
      - Activate user account.

--- a/fittrackee/tests/users/test_auth_api.py
+++ b/fittrackee/tests/users/test_auth_api.py
@@ -21,6 +21,7 @@ from fittrackee.users.models import (
     UserSportPreference,
     UserSportPreferenceEquipment,
 )
+from fittrackee.users.roles import UserRole
 from fittrackee.users.utils.token import get_user_token
 from fittrackee.visibility_levels import VisibilityLevel
 from fittrackee.workouts.models import Sport, Workout
@@ -299,6 +300,26 @@ class TestUserRegistration(ApiTestCaseMixin):
         data = json.loads(response.data.decode())
         assert data['status'] == 'success'
         assert 'auth_token' not in data
+
+    def test_it_creates_user_with_user_role(self, app: Flask) -> None:
+        client = app.test_client()
+        username = self.random_string()
+
+        client.post(
+            '/api/auth/register',
+            data=json.dumps(
+                dict(
+                    username=username,
+                    email=self.random_email(),
+                    password=self.random_string(),
+                    accepted_policy=True,
+                )
+            ),
+            content_type='application/json',
+        )
+
+        new_user = User.query.filter_by(username=username).first()
+        assert new_user.role == UserRole.USER.value
 
     def test_it_creates_user_with_default_date_format(
         self, app: Flask

--- a/fittrackee/users/commands.py
+++ b/fittrackee/users/commands.py
@@ -46,15 +46,22 @@ def users_cli() -> None:
         f' Supported languages: {", ".join(SUPPORTED_LANGUAGES)}.'
     ),
 )
+@click.option(
+    '--role', type=click.Choice(UserRole.db_choices()), help='Set user role.'
+)
 def create_user(
-    username: str, email: str, password: Optional[str], lang: Optional[str]
+    username: str,
+    email: str,
+    password: Optional[str],
+    lang: Optional[str],
+    role: Optional[str],
 ) -> None:
     """Create an active user account."""
     with app.app_context():
         try:
             user_manager_service = UserManagerService(username)
             user, user_password = user_manager_service.create_user(
-                email=email, password=password, check_email=True
+                email=email, password=password, check_email=True, role=role
             )
             if user:
                 db.session.add(user)

--- a/fittrackee/users/users_service.py
+++ b/fittrackee/users/users_service.py
@@ -159,6 +159,7 @@ class UserManagerService:
         email: str,
         password: Optional[str] = None,
         check_email: bool = False,
+        role: Optional[str] = None,
     ) -> Tuple[Optional[User], Optional[str]]:
         if not password:
             password = secrets.token_urlsafe(30)
@@ -192,6 +193,12 @@ class UserManagerService:
         new_user.timezone = USER_TIMEZONE
         new_user.date_format = USER_DATE_FORMAT
         new_user.confirmation_token = secrets.token_urlsafe(30)
+
+        if role is not None:
+            if role not in UserRole.db_choices():
+                raise InvalidUserRole()
+            new_user.role = UserRole[role.upper()].value
+
         db.session.add(new_user)
         db.session.flush()
 
@@ -201,10 +208,11 @@ class UserManagerService:
         self,
         email: str,
         password: Optional[str] = None,
+        role: Optional[str] = None,
     ) -> Tuple[Optional[User], Optional[str]]:
         try:
             new_user, password = self.create_user(
-                email, password, check_email=True
+                email, password, check_email=True, role=role
             )
             if new_user:
                 new_user.language = 'en'


### PR DESCRIPTION
Add `--role` option to create user command in order to create user with a given role:

```shell
$ ftcli users create --help
Usage: ftcli users create [OPTIONS] USERNAME

  Create an active user account.

Options:
  --email TEXT                    User email.  [required]
  --password TEXT                 User password. If not provided, a random
                                  password is generated.
  --lang TEXT                     User preference for interface language (two-
                                  letter code, ISO 639-1). If not provided or
                                  not supported, it falls back to English
                                  ('en'). Supported languages: bg, cs, de, en,
                                  es, eu, fr, gl, it, nb, nl, pl, pt, ru.
  --role [owner|admin|moderator|user]
                                  Set user role.
  --help                          Show this message and exit.

```