### PR TITLE
replace deprecated datetime.utcnow()

### DIFF
--- a/fittrackee/application/app_config.py
+++ b/fittrackee/application/app_config.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Union
 
 from flask import Blueprint, current_app, request
@@ -183,7 +183,7 @@ def update_application_config(auth_user: User) -> Union[Dict, HttpResponse]:
             privacy_policy = config_data.get('privacy_policy')
             config.privacy_policy = privacy_policy if privacy_policy else None
             config.privacy_policy_date = (
-                datetime.utcnow() if privacy_policy else None
+                datetime.now(timezone.utc) if privacy_policy else None
             )
 
         if config.max_zip_file_size < config.max_single_file_size:

--- a/fittrackee/application/models.py
+++ b/fittrackee/application/models.py
@@ -9,8 +9,8 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import text
 
 from fittrackee import BaseModel, db
+from fittrackee.database import TZDateTime
 from fittrackee.users.models import User
-from fittrackee.utils import TZDateTime
 
 
 class AppConfig(BaseModel):

--- a/fittrackee/application/models.py
+++ b/fittrackee/application/models.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql import text
 
 from fittrackee import BaseModel, db
 from fittrackee.users.models import User
+from fittrackee.utils import TZDateTime
 
 
 class AppConfig(BaseModel):
@@ -22,7 +23,7 @@ class AppConfig(BaseModel):
     )
     max_zip_file_size = db.Column(db.Integer, default=10485760, nullable=False)
     admin_contact = db.Column(db.String(255), nullable=True)
-    privacy_policy_date = db.Column(db.DateTime, nullable=True)
+    privacy_policy_date = db.Column(TZDateTime, nullable=True)
     privacy_policy = db.Column(db.Text, nullable=True)
     about = db.Column(db.Text, nullable=True)
     stats_workouts_limit = db.Column(db.Integer, default=10000, nullable=False)

--- a/fittrackee/application/utils.py
+++ b/fittrackee/application/utils.py
@@ -4,7 +4,7 @@ from flask import Flask
 
 from fittrackee import db
 
-from ..utils import get_datetime_in_utc
+from ..dates import get_datetime_in_utc
 from .models import AppConfig
 
 MAX_FILE_SIZE = 1 * 1024 * 1024  # 1MB

--- a/fittrackee/application/utils.py
+++ b/fittrackee/application/utils.py
@@ -1,10 +1,10 @@
-from datetime import datetime
 from typing import Dict, List
 
 from flask import Flask
 
 from fittrackee import db
 
+from ..utils import get_datetime_in_utc
 from .models import AppConfig
 
 MAX_FILE_SIZE = 1 * 1024 * 1024  # 1MB
@@ -39,7 +39,7 @@ def update_app_config_from_database(
     current_app.config['privacy_policy_date'] = (
         db_config.privacy_policy_date
         if db_config.privacy_policy
-        else datetime.strptime(
+        else get_datetime_in_utc(
             current_app.config['DEFAULT_PRIVACY_POLICY_DATA'],
             '%Y-%m-%d %H:%M:%S',
         )

--- a/fittrackee/comments/comments.py
+++ b/fittrackee/comments/comments.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional, Tuple, Union
 
 from flask import Blueprint, request
@@ -440,7 +440,7 @@ def update_workout_comment(
 
     try:
         comment.text = clean_input(comment_data['text'])
-        comment.modification_date = datetime.utcnow()
+        comment.modification_date = datetime.now(timezone.utc)
         comment.update_mentions()
         db.session.commit()
         return {

--- a/fittrackee/comments/models.py
+++ b/fittrackee/comments/models.py
@@ -11,7 +11,9 @@ from sqlalchemy.sql import select, text
 from sqlalchemy.types import Enum
 
 from fittrackee import BaseModel, db
-from fittrackee.utils import TZDateTime, aware_utc_now, encode_uuid
+from fittrackee.database import TZDateTime
+from fittrackee.dates import aware_utc_now
+from fittrackee.utils import encode_uuid
 from fittrackee.visibility_levels import VisibilityLevel, can_view
 
 from .exceptions import CommentForbiddenException

--- a/fittrackee/comments/models.py
+++ b/fittrackee/comments/models.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 from uuid import uuid4
 
@@ -11,7 +11,7 @@ from sqlalchemy.sql import select, text
 from sqlalchemy.types import Enum
 
 from fittrackee import BaseModel, db
-from fittrackee.utils import encode_uuid
+from fittrackee.utils import TZDateTime, aware_utc_now, encode_uuid
 from fittrackee.visibility_levels import VisibilityLevel, can_view
 
 from .exceptions import CommentForbiddenException
@@ -91,15 +91,15 @@ class Comment(BaseModel):
         index=True,
         nullable=True,
     )
-    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
-    modification_date = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(TZDateTime, default=aware_utc_now)
+    modification_date = db.Column(TZDateTime, nullable=True)
     text = db.Column(db.String(), nullable=False)
     text_visibility = db.Column(
         Enum(VisibilityLevel, name='visibility_levels'),
         server_default='PRIVATE',
         nullable=False,
     )
-    suspended_at = db.Column(db.DateTime, nullable=True)
+    suspended_at = db.Column(TZDateTime, nullable=True)
 
     mentions = db.relationship(
         "Mention",
@@ -133,14 +133,14 @@ class Comment(BaseModel):
         workout_id: int,
         text: str,
         text_visibility: VisibilityLevel,
-        created_at: Optional[datetime.datetime] = None,
+        created_at: Optional[datetime] = None,
     ) -> None:
         self.user_id = user_id
         self.workout_id = workout_id
         self.text = text
         self.text_visibility = text_visibility
         self.created_at = (
-            datetime.datetime.utcnow() if created_at is None else created_at
+            datetime.now(timezone.utc) if created_at is None else created_at
         )
 
     @property
@@ -294,20 +294,18 @@ class Mention(BaseModel):
         db.ForeignKey('users.id', ondelete="CASCADE"),
         primary_key=True,
     )
-    created_at = db.Column(
-        db.DateTime, nullable=False, default=datetime.datetime.utcnow
-    )
+    created_at = db.Column(TZDateTime, nullable=False, default=aware_utc_now)
 
     def __init__(
         self,
         comment_id: int,
         user_id: int,
-        created_at: Optional[datetime.datetime] = None,
+        created_at: Optional[datetime] = None,
     ):
         self.comment_id = comment_id
         self.user_id = user_id
         self.created_at = (
-            datetime.datetime.utcnow() if created_at is None else created_at
+            datetime.now(timezone.utc) if created_at is None else created_at
         )
 
 
@@ -457,7 +455,7 @@ class CommentLike(BaseModel):
         ),
     )
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    created_at = db.Column(db.DateTime, nullable=False)
+    created_at = db.Column(TZDateTime, nullable=False)
     user_id = db.Column(
         db.Integer,
         db.ForeignKey('users.id', ondelete='CASCADE'),
@@ -477,12 +475,12 @@ class CommentLike(BaseModel):
         self,
         user_id: int,
         comment_id: int,
-        created_at: Optional[datetime.datetime] = None,
+        created_at: Optional[datetime] = None,
     ) -> None:
         self.user_id = user_id
         self.comment_id = comment_id
         self.created_at = (
-            datetime.datetime.utcnow() if created_at is None else created_at
+            datetime.now(timezone.utc) if created_at is None else created_at
         )
 
 

--- a/fittrackee/database.py
+++ b/fittrackee/database.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import DateTime, TypeDecorator
+from sqlalchemy.engine import Dialect
+
+
+# Store Timezone Aware Timestamps as Timezone Naive UTC
+# source: https://docs.sqlalchemy.org/en/14/core/custom_types.html#store-timezone-aware-timestamps-as-timezone-naive-utc  # noqa
+class TZDateTime(TypeDecorator):
+    impl = DateTime
+    cache_ok = True
+
+    def process_bind_param(
+        self, value: Optional[datetime], dialect: 'Dialect'
+    ) -> Optional[datetime]:
+        if value is not None:
+            if not value.tzinfo or value.tzinfo.utcoffset(value) is None:
+                raise TypeError("tzinfo is required")
+            value = value.astimezone(timezone.utc).replace(tzinfo=None)
+        return value
+
+    def process_result_value(
+        self, value: Optional[datetime], dialect: 'Dialect'
+    ) -> Optional[datetime]:
+        if value is not None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value

--- a/fittrackee/dates.py
+++ b/fittrackee/dates.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Optional
+
+import humanize
+import pytz
+from babel.dates import format_datetime
+
+from fittrackee.languages import LANGUAGES_DATE_STRING
+from fittrackee.users.constants import USER_DATE_FORMAT, USER_TIMEZONE
+from fittrackee.users.utils.language import get_language
+
+if TYPE_CHECKING:
+    from fittrackee.users.models import User
+
+
+def get_date_string_for_user(date_to_format: datetime, user: "User") -> str:
+    """
+    Note: date_to_format is a timezone-aware datetime in UTC
+    """
+    user_language = get_language(user.language)
+    user_timezone = user.timezone if user.timezone else USER_TIMEZONE
+    user_date_format = (
+        user.date_format if user.date_format else USER_DATE_FORMAT
+    )
+
+    date_format = (
+        LANGUAGES_DATE_STRING[user_language]
+        if user_date_format == "date_string"
+        else user_date_format
+    )
+    return format_datetime(
+        date_to_format.astimezone(pytz.timezone(user_timezone)),
+        format=f"{date_format} - HH:mm:ss",
+        locale=user_language,
+    )
+
+
+def get_readable_duration(duration: int, locale: Optional[str] = None) -> str:
+    """
+    Return readable and localized duration from duration in seconds
+    """
+    if locale is None:
+        locale = 'en'
+    if locale != 'en':
+        try:
+            _t = humanize.i18n.activate(locale)  # noqa
+        except FileNotFoundError:
+            locale = 'en'
+    readable_duration = humanize.naturaldelta(timedelta(seconds=duration))
+    if locale != 'en':
+        humanize.i18n.deactivate()
+    return readable_duration
+
+
+def aware_utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def get_datetime_in_utc(
+    date_string: str, date_format: str = '%Y-%m-%d'
+) -> datetime:
+    return datetime.strptime(date_string, date_format).replace(
+        tzinfo=timezone.utc
+    )

--- a/fittrackee/equipments/equipments.py
+++ b/fittrackee/equipments/equipments.py
@@ -20,10 +20,10 @@ from fittrackee.users.models import (
     UserSportPreferenceEquipment,
 )
 from fittrackee.utils import decode_short_id
-from fittrackee.workouts.models import Sport, Workout, WorkoutEquipment
+from fittrackee.workouts.models import Sport, Workout
 
 from .exceptions import InvalidEquipmentsException
-from .models import Equipment, EquipmentType
+from .models import Equipment, EquipmentType, WorkoutEquipment
 from .utils import SPORT_EQUIPMENT_TYPES
 
 equipments_blueprint = Blueprint('equipments', __name__)

--- a/fittrackee/equipments/models.py
+++ b/fittrackee/equipments/models.py
@@ -7,7 +7,9 @@ from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql.expression import text
 
 from fittrackee import db
-from fittrackee.utils import TZDateTime, aware_utc_now, encode_uuid
+from fittrackee.database import TZDateTime
+from fittrackee.dates import aware_utc_now
+from fittrackee.utils import encode_uuid
 
 BaseModel: DeclarativeMeta = db.Model
 

--- a/fittrackee/equipments/models.py
+++ b/fittrackee/equipments/models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Dict
 from uuid import uuid4
 
@@ -8,7 +7,7 @@ from sqlalchemy.schema import UniqueConstraint
 from sqlalchemy.sql.expression import text
 
 from fittrackee import db
-from fittrackee.utils import encode_uuid
+from fittrackee.utils import TZDateTime, aware_utc_now, encode_uuid
 
 BaseModel: DeclarativeMeta = db.Model
 
@@ -57,7 +56,7 @@ class Equipment(BaseModel):
     equipment_type_id = db.Column(
         db.Integer, db.ForeignKey('equipment_types.id')
     )
-    creation_date = db.Column(db.DateTime, default=datetime.utcnow)
+    creation_date = db.Column(TZDateTime, default=aware_utc_now)
     is_active = db.Column(db.Boolean, default=True, nullable=False)
     total_distance = db.Column(
         db.Numeric(10, 3),

--- a/fittrackee/reports/models.py
+++ b/fittrackee/reports/models.py
@@ -10,9 +10,11 @@ from sqlalchemy.orm import Mapper, Session
 from fittrackee import BaseModel, db
 from fittrackee.comments.exceptions import CommentForbiddenException
 from fittrackee.comments.models import Comment
+from fittrackee.database import TZDateTime
+from fittrackee.dates import aware_utc_now
 from fittrackee.users.models import Notification, User
 from fittrackee.users.roles import UserRole
-from fittrackee.utils import TZDateTime, aware_utc_now, encode_uuid
+from fittrackee.utils import encode_uuid
 from fittrackee.workouts.exceptions import WorkoutForbiddenException
 from fittrackee.workouts.models import Workout
 

--- a/fittrackee/reports/models.py
+++ b/fittrackee/reports/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional, Union
 from uuid import uuid4
 
@@ -12,7 +12,7 @@ from fittrackee.comments.exceptions import CommentForbiddenException
 from fittrackee.comments.models import Comment
 from fittrackee.users.models import Notification, User
 from fittrackee.users.roles import UserRole
-from fittrackee.utils import encode_uuid
+from fittrackee.utils import TZDateTime, aware_utc_now, encode_uuid
 from fittrackee.workouts.exceptions import WorkoutForbiddenException
 from fittrackee.workouts.models import Workout
 
@@ -62,9 +62,9 @@ ALL_ACTION_TYPES = REPORT_ACTION_TYPES + OBJECTS_ACTION_TYPES
 class Report(BaseModel):
     __tablename__ = 'reports'
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=True)
-    resolved_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(TZDateTime, default=aware_utc_now)
+    updated_at = db.Column(TZDateTime, nullable=True)
+    resolved_at = db.Column(TZDateTime, nullable=True)
     reported_by = db.Column(
         db.Integer,
         db.ForeignKey('users.id', ondelete='SET NULL'),
@@ -183,7 +183,9 @@ class Report(BaseModel):
         if user_id == reported_by:
             raise InvalidReporterException()
 
-        self.created_at = created_at if created_at else datetime.utcnow()
+        self.created_at = (
+            created_at if created_at else datetime.now(timezone.utc)
+        )
         self.note = note
         self.object_type = object_type
         self.reported_by = reported_by
@@ -289,7 +291,7 @@ def on_report_insert(
 class ReportComment(BaseModel):
     __tablename__ = 'report_comments'
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    created_at = db.Column(TZDateTime, default=aware_utc_now)
     report_id = db.Column(
         db.Integer,
         db.ForeignKey('reports.id', ondelete='CASCADE'),
@@ -316,7 +318,9 @@ class ReportComment(BaseModel):
         comment: str,
         created_at: Optional[datetime] = None,
     ):
-        self.created_at = created_at if created_at else datetime.utcnow()
+        self.created_at = (
+            created_at if created_at else datetime.now(timezone.utc)
+        )
         self.comment = comment
         self.report_id = report_id
         self.user_id = user_id
@@ -342,7 +346,7 @@ class ReportAction(BaseModel):
         unique=True,
         nullable=False,
     )
-    created_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+    created_at = db.Column(TZDateTime, default=aware_utc_now, index=True)
     moderator_id = db.Column(
         db.Integer,
         db.ForeignKey("users.id", ondelete="SET NULL"),
@@ -427,7 +431,9 @@ class ReportAction(BaseModel):
 
         self.action_type = action_type
         self.moderator_id = moderator_id
-        self.created_at = created_at if created_at else datetime.utcnow()
+        self.created_at = (
+            created_at if created_at else datetime.now(timezone.utc)
+        )
         self.comment_id = (
             comment_id if action_type in COMMENT_ACTION_TYPES else None
         )
@@ -535,10 +541,8 @@ class ReportActionAppeal(BaseModel):
         index=True,
         nullable=True,
     )
-    created_at = db.Column(
-        db.DateTime, default=datetime.utcnow, nullable=False
-    )
-    updated_at = db.Column(db.DateTime)
+    created_at = db.Column(TZDateTime, default=aware_utc_now, nullable=False)
+    updated_at = db.Column(TZDateTime)
     approved = db.Column(db.Boolean, nullable=True)
     text = db.Column(db.String(), nullable=False)
     reason = db.Column(db.String(), nullable=True)
@@ -574,7 +578,9 @@ class ReportActionAppeal(BaseModel):
         if action.user_id != user_id:
             raise InvalidReportActionAppealUserException()
         self.action_id = action_id
-        self.created_at = created_at if created_at else datetime.utcnow()
+        self.created_at = (
+            created_at if created_at else datetime.now(timezone.utc)
+        )
         self.text = text
         self.user_id = user_id
 

--- a/fittrackee/reports/reports_email_service.py
+++ b/fittrackee/reports/reports_email_service.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional, Tuple
 from flask import current_app
 
 from fittrackee.comments.models import Comment
+from fittrackee.dates import get_date_string_for_user
 from fittrackee.emails.tasks import (
     appeal_rejected_email,
     comment_suspension_email,
@@ -16,7 +17,6 @@ from fittrackee.emails.tasks import (
 )
 from fittrackee.users.models import User
 from fittrackee.users.utils.language import get_language
-from fittrackee.utils import get_date_string_for_user
 from fittrackee.workouts.models import Workout
 
 from .exceptions import InvalidReportActionException

--- a/fittrackee/reports/reports_service.py
+++ b/fittrackee/reports/reports_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional, Union
 
 from sqlalchemy import func
@@ -92,7 +92,7 @@ class ReportService:
         )
         db.session.add(new_report_comment)
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report.updated_at = now
         report_action = None
         if resolved is not None:
@@ -139,7 +139,7 @@ class ReportService:
         if not reported_user:
             raise InvalidReportActionException("invalid 'username'")
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report_action = None
         if action_type in ALL_USER_ACTION_TYPES:
             username = data.get("username")
@@ -193,7 +193,7 @@ class ReportService:
                     )
                     if appeal:
                         appeal.approved = None
-                        appeal.updated_at = datetime.utcnow()
+                        appeal.updated_at = datetime.now(timezone.utc)
                         db.session.flush()
 
         elif action_type in COMMENT_ACTION_TYPES + WORKOUT_ACTION_TYPES:
@@ -248,7 +248,7 @@ class ReportService:
                 )
                 if appeal:
                     appeal.approved = None
-                    appeal.updated_at = datetime.utcnow()
+                    appeal.updated_at = datetime.now(timezone.utc)
                     db.session.flush()
             db.session.flush()
         else:
@@ -262,7 +262,7 @@ class ReportService:
         appeal.moderator_id = moderator.id
         appeal.approved = data["approved"]
         appeal.reason = data["reason"]
-        appeal.updated_at = datetime.utcnow()
+        appeal.updated_at = datetime.now(timezone.utc)
 
         action = appeal.action
         content = None
@@ -293,7 +293,7 @@ class ReportService:
                 new_report_action = ReportAction(
                     moderator_id=moderator.id,
                     action_type="user_warning_lifting",
-                    created_at=datetime.utcnow(),
+                    created_at=datetime.now(timezone.utc),
                     report_id=action.report_id,
                     user_id=action.user_id,
                 )
@@ -311,7 +311,7 @@ class ReportService:
                 new_report_action = ReportAction(
                     moderator_id=moderator.id,
                     action_type=f"{content_type}_unsuspension",
-                    created_at=datetime.utcnow(),
+                    created_at=datetime.now(timezone.utc),
                     report_id=action.report_id,
                     user_id=action.user_id,
                     **content_id,

--- a/fittrackee/tests/application/test_app_config_api.py
+++ b/fittrackee/tests/application/test_app_config_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pytest
@@ -443,7 +443,7 @@ class TestUpdateConfig(ApiTestCaseMixin):
             app, user_1_admin.email
         )
         privacy_policy = self.random_string()
-        privacy_policy_date = datetime.utcnow()
+        privacy_policy_date = datetime.now(timezone.utc)
 
         with travel(privacy_policy_date, tick=False):
             response = client.patch(
@@ -470,7 +470,7 @@ class TestUpdateConfig(ApiTestCaseMixin):
     ) -> None:
         app_config = AppConfig.query.first()
         app_config.privacy_policy = self.random_string()
-        app_config.privacy_policy_date = datetime.utcnow()
+        app_config.privacy_policy_date = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email

--- a/fittrackee/tests/application/test_app_config_model.py
+++ b/fittrackee/tests/application/test_app_config_model.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from flask import Flask
@@ -109,7 +109,7 @@ class TestConfigModel:
     def test_it_returns_custom_privacy_policy(self, app: Flask) -> None:
         app_config = AppConfig.query.first()
         privacy_policy = random_string()
-        privacy_policy_date = datetime.utcnow()
+        privacy_policy_date = datetime.now(timezone.utc)
         app_config.privacy_policy = privacy_policy
         app_config.privacy_policy_date = privacy_policy_date
 

--- a/fittrackee/tests/comments/test_comment_likes_model.py
+++ b/fittrackee/tests/comments/test_comment_likes_model.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import Flask
 from time_machine import travel
@@ -21,7 +21,7 @@ class TestCommentLikeModel(CommentMixin):
         workout_cycling_user_1: Workout,
     ) -> None:
         comment = self.create_comment(user_1, workout_cycling_user_1)
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
 
         like = CommentLike(
             user_id=user_2.id,
@@ -42,7 +42,7 @@ class TestCommentLikeModel(CommentMixin):
         workout_cycling_user_1: Workout,
     ) -> None:
         comment = self.create_comment(user_1, workout_cycling_user_1)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         with travel(now, tick=False):
             like = CommentLike(user_id=user_2.id, comment_id=comment.id)
 

--- a/fittrackee/tests/comments/test_comments_api.py
+++ b/fittrackee/tests/comments/test_comments_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List
 
 import pytest
@@ -313,7 +313,7 @@ class TestPostWorkoutComment(CommentMixin, ApiTestCaseMixin, BaseTestMixin):
         user_2.approves_follow_request_from(user_1)
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
         comment_text = self.random_string()
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -660,7 +660,7 @@ class TestGetWorkoutCommentAsUser(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -694,7 +694,7 @@ class TestGetWorkoutCommentAsUser(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -725,7 +725,7 @@ class TestGetWorkoutCommentAsUser(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -840,7 +840,7 @@ class TestGetWorkoutCommentAsFollower(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.FOLLOWERS,
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -875,7 +875,7 @@ class TestGetWorkoutCommentAsFollower(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PRIVATE,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -956,7 +956,7 @@ class TestGetWorkoutCommentAsOwner(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PRIVATE,
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -988,7 +988,7 @@ class TestGetWorkoutCommentAsOwner(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PRIVATE,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -1058,7 +1058,7 @@ class TestGetWorkoutCommentAsUnauthenticatedUser(
             workout_cycling_user_1,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client = app.test_client()
 
@@ -1321,7 +1321,7 @@ class TestGetWorkoutCommentsAsUser(GetWorkoutCommentsTestCase):
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -1464,7 +1464,7 @@ class TestGetWorkoutCommentsAsFollower(GetWorkoutCommentsTestCase):
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.FOLLOWERS,
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -1540,7 +1540,7 @@ class TestGetWorkoutCommentsAsOwner(GetWorkoutCommentsTestCase):
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PRIVATE,
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -1632,7 +1632,7 @@ class TestGetWorkoutComments(GetWorkoutCommentsTestCase):
                 workout_cycling_user_2,
                 text_visibility=VisibilityLevel.PUBLIC,
             )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -1894,7 +1894,7 @@ class TestDeleteWorkoutComment(ApiTestCaseMixin, BaseTestMixin, CommentMixin):
             workout_cycling_user_1,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -2167,7 +2167,7 @@ class TestPatchWorkoutComment(ApiTestCaseMixin, BaseTestMixin, CommentMixin):
             workout_cycling_user_1,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -2460,7 +2460,7 @@ class TestPostWorkoutCommentSuspensionAppeal(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -2495,7 +2495,7 @@ class TestPostWorkoutCommentSuspensionAppeal(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         self.create_report_comment_action(user_2_admin, user_1, comment)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
@@ -2525,7 +2525,7 @@ class TestPostWorkoutCommentSuspensionAppeal(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         action = self.create_report_comment_action(
             user_2_admin, user_1, comment
         )
@@ -2534,7 +2534,7 @@ class TestPostWorkoutCommentSuspensionAppeal(
             app, user_1.email
         )
         text = self.random_string()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             response = client.post(
@@ -2569,7 +2569,7 @@ class TestPostWorkoutCommentSuspensionAppeal(
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         action = self.create_report_comment_action(
             user_2_admin, user_1, comment
         )

--- a/fittrackee/tests/comments/test_comments_likes_api.py
+++ b/fittrackee/tests/comments/test_comments_likes_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -147,7 +147,7 @@ class TestCommentLikePost(CommentMixin, ApiTestCaseMixin, BaseTestMixin):
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.FOLLOWERS,
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -175,7 +175,7 @@ class TestCommentLikePost(CommentMixin, ApiTestCaseMixin, BaseTestMixin):
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -450,7 +450,7 @@ class TestCommentUndoLikePost(CommentMixin, ApiTestCaseMixin, BaseTestMixin):
         )
         like = CommentLike(user_id=user_1.id, comment_id=comment.id)
         db.session.add(like)
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
 
         response = client.post(

--- a/fittrackee/tests/comments/test_comments_models.py
+++ b/fittrackee/tests/comments/test_comments_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from flask import Flask
@@ -25,7 +25,7 @@ class TestWorkoutCommentModel(ReportMixin, CommentMixin):
         workout_cycling_user_1: Workout,
     ) -> None:
         text = self.random_string()
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
         comment = self.create_comment(
             user_1,
             workout_cycling_user_1,
@@ -48,7 +48,7 @@ class TestWorkoutCommentModel(ReportMixin, CommentMixin):
         sport_1_cycling: Sport,
         workout_cycling_user_1: Workout,
     ) -> None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         with travel(now, tick=False):
             comment = self.create_comment(user_1, workout_cycling_user_1)
 
@@ -139,7 +139,7 @@ class TestWorkoutCommentModel(ReportMixin, CommentMixin):
         expected_report_action = self.create_report_comment_actions(
             user_1_admin, user_2, comment
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
 
         assert comment.suspension_action == expected_report_action
 
@@ -190,7 +190,7 @@ class TestWorkoutCommentModelSerializeForCommentOwner(
             text_visibility=input_visibility,
         )
         if suspended:
-            comment.suspended_at = datetime.utcnow()
+            comment.suspended_at = datetime.now(timezone.utc)
             suspended_at = {
                 "suspended": True,
                 "suspended_at": comment.suspended_at,
@@ -285,7 +285,7 @@ class TestWorkoutCommentModelSerializeForCommentOwner(
         expected_report_action = self.create_report_comment_actions(
             user_2_admin, user_1, comment
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
 
         serialized_comment = comment.serialize(user_1)
 
@@ -590,7 +590,7 @@ class TestWorkoutCommentModelSerializeForModerator(CommentMixin):
             with_mentions=True,
         )
         if suspended:
-            comment.suspended_at = datetime.utcnow()
+            comment.suspended_at = datetime.now(timezone.utc)
             suspended_at = {
                 "suspended": True,
                 "suspended_at": comment.suspended_at,
@@ -634,7 +634,7 @@ class TestWorkoutCommentModelSerializeForModerator(CommentMixin):
             text_visibility=VisibilityLevel.PUBLIC,
             with_mentions=True,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
 
         serialized_comment = comment.serialize(user_1_moderator)
 
@@ -691,7 +691,7 @@ class TestWorkoutCommentModelSerializeForAdmin(CommentMixin):
             text_visibility=VisibilityLevel.FOLLOWERS,
             with_mentions=True,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
 
         serialized_comment = comment.serialize(user_1_admin, for_report=True)
 

--- a/fittrackee/tests/comments/test_mentions_models.py
+++ b/fittrackee/tests/comments/test_mentions_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from flask import Flask
@@ -29,7 +29,7 @@ class TestMentionModel(CommentMixin):
         workout_cycling_user_1: Workout,
     ) -> None:
         comment = self.create_comment(user_1, workout_cycling_user_1)
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
 
         mention = Mention(
             comment_id=comment.id, user_id=user_1.id, created_at=created_at
@@ -47,7 +47,7 @@ class TestMentionModel(CommentMixin):
         workout_cycling_user_1: Workout,
     ) -> None:
         comment = self.create_comment(user_1, workout_cycling_user_1)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         with travel(now, tick=False):
             mention = Mention(comment_id=comment.id, user_id=user_1.id)
 

--- a/fittrackee/tests/equipments/test_equipment_types_api.py
+++ b/fittrackee/tests/equipments/test_equipment_types_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from flask import Flask
@@ -91,7 +91,7 @@ class TestGetEquipmentTypes(ApiTestCaseMixin):
         equipment_type_1_shoe_inactive: EquipmentType,
         equipment_type_2_bike: EquipmentType,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )

--- a/fittrackee/tests/equipments/test_equipments_api.py
+++ b/fittrackee/tests/equipments/test_equipments_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Tuple
 
 import pytest
@@ -34,7 +34,7 @@ class TestGetEquipments(ApiTestCaseMixin):
     def test_it_does_not_return_error_if_user_suspended(
         self, app: Flask, user_1: User
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
@@ -217,7 +217,7 @@ class TestGetEquipment(ApiTestCaseMixin):
         equipment_bike_user_1: Equipment,
         equipment_shoes_user_1: Equipment,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )

--- a/fittrackee/tests/fixtures/fixtures_equipments.py
+++ b/fittrackee/tests/fixtures/fixtures_equipments.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -138,7 +138,7 @@ def workout_w_shoes_equipment(
     workout = Workout(
         user_id=user_1.id,
         sport_id=sport_2_running.id,
-        workout_date=datetime.strptime('20/03/2017', '%d/%m/%Y'),
+        workout_date=datetime(2017, 3, 20, tzinfo=timezone.utc),
         distance=5,
         duration=timedelta(seconds=1024),
     )

--- a/fittrackee/tests/fixtures/fixtures_users.py
+++ b/fittrackee/tests/fixtures/fixtures_users.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -15,7 +15,7 @@ def user_1() -> User:
     user = User(username='test', email='test@test.com', password='12345678')
     user.is_active = True
     user.hide_profile_in_users_directory = False
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -26,7 +26,7 @@ def user_1_upper() -> User:
     user = User(username='TEST', email='TEST@TEST.COM', password='12345678')
     user.is_active = True
     user.hide_profile_in_users_directory = False
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -40,7 +40,7 @@ def user_1_admin() -> User:
     admin.role = UserRole.ADMIN.value
     admin.hide_profile_in_users_directory = False
     admin.is_active = True
-    admin.accepted_policy = datetime.datetime.utcnow()
+    admin.accepted_policy = datetime.now(timezone.utc)
     db.session.add(admin)
     db.session.commit()
     return admin
@@ -56,7 +56,7 @@ def user_1_moderator() -> User:
     moderator.role = UserRole.MODERATOR.value
     moderator.hide_profile_in_users_directory = False
     moderator.is_active = True
-    moderator.accepted_policy = datetime.datetime.utcnow()
+    moderator.accepted_policy = datetime.now(timezone.utc)
     db.session.add(moderator)
     db.session.commit()
     return moderator
@@ -70,7 +70,7 @@ def user_1_owner() -> User:
     owner.role = UserRole.OWNER.value
     owner.hide_profile_in_users_directory = False
     owner.is_active = True
-    owner.accepted_policy = datetime.datetime.utcnow()
+    owner.accepted_policy = datetime.now(timezone.utc)
     db.session.add(owner)
     db.session.commit()
     return owner
@@ -85,10 +85,10 @@ def user_1_full() -> User:
     user.location = 'somewhere'
     user.language = 'en'
     user.timezone = 'America/New_York'
-    user.birth_date = datetime.datetime.strptime('01/01/1980', '%d/%m/%Y')
+    user.birth_date = datetime(1980, 1, 1, tzinfo=timezone.utc)
     user.is_active = True
     user.hide_profile_in_users_directory = False
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -103,11 +103,11 @@ def user_1_raw_speed() -> User:
     user.location = 'somewhere'
     user.language = 'en'
     user.timezone = 'America/New_York'
-    user.birth_date = datetime.datetime.strptime('01/01/1980', '%d/%m/%Y')
+    user.birth_date = datetime(1980, 1, 1, tzinfo=timezone.utc)
     user.is_active = True
     user.hide_profile_in_users_directory = False
     user.use_raw_gpx_speed = True
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -119,7 +119,7 @@ def user_1_paris() -> User:
     user.timezone = 'Europe/Paris'
     user.is_active = True
     user.hide_profile_in_users_directory = False
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -130,7 +130,7 @@ def user_2() -> User:
     user = User(username='toto', email='toto@toto.com', password='12345678')
     user.is_active = True
     user.hide_profile_in_users_directory = False
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -142,7 +142,7 @@ def user_2_owner() -> User:
     user.is_active = True
     user.hide_profile_in_users_directory = False
     user.role = UserRole.OWNER.value
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -154,7 +154,7 @@ def user_2_admin() -> User:
     user.is_active = True
     user.hide_profile_in_users_directory = False
     user.role = UserRole.ADMIN.value
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -166,7 +166,7 @@ def user_2_moderator() -> User:
     user.is_active = True
     user.hide_profile_in_users_directory = False
     user.role = UserRole.MODERATOR.value
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -178,7 +178,7 @@ def user_3() -> User:
     user.is_active = True
     user.hide_profile_in_users_directory = False
     user.weekm = True
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -191,7 +191,7 @@ def user_3_admin() -> User:
     user.hide_profile_in_users_directory = False
     user.role = UserRole.ADMIN.value
     user.weekm = True
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -214,7 +214,7 @@ def inactive_user() -> User:
         username='inactive', email='inactive@example.com', password='12345678'
     )
     user.confirmation_token = random_string()
-    user.accepted_policy = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user
@@ -229,8 +229,8 @@ def suspended_user() -> User:
     )
     user.is_active = True
     user.hide_profile_in_users_directory = False
-    user.accepted_policy = datetime.datetime.utcnow()
-    user.suspended_at = datetime.datetime.utcnow()
+    user.accepted_policy = datetime.now(timezone.utc)
+    user.suspended_at = datetime.now(timezone.utc)
     db.session.add(user)
     db.session.commit()
     return user

--- a/fittrackee/tests/fixtures/fixtures_workouts.py
+++ b/fittrackee/tests/fixtures/fixtures_workouts.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from typing import Generator, Iterator, List
 from unittest.mock import Mock, patch
@@ -93,9 +93,9 @@ def workout_cycling_user_1() -> Workout:
         user_id=1,
         sport_id=1,
         # workout_date: 'Mon, 01 Jan 2018 00:00:00 GMT'
-        workout_date=datetime.datetime.strptime('01/01/2018', '%d/%m/%Y'),
+        workout_date=datetime(2018, 1, 1, tzinfo=timezone.utc),
         distance=10,
-        duration=datetime.timedelta(seconds=3600),
+        duration=timedelta(seconds=3600),
     )
     update_workout(workout)
     db.session.add(workout)
@@ -109,9 +109,9 @@ def another_workout_cycling_user_1() -> Workout:
         user_id=1,
         sport_id=1,
         # workout_date: 'Mon, 01 Jan 2024 00:00:00 GMT'
-        workout_date=datetime.datetime.strptime('01/01/2024', '%d/%m/%Y'),
+        workout_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
         distance=18,
-        duration=datetime.timedelta(seconds=3600),
+        duration=timedelta(seconds=3600),
     )
     update_workout(workout)
     db.session.add(workout)
@@ -128,7 +128,7 @@ def workout_cycling_user_1_segment(
         workout_uuid=workout_cycling_user_1.uuid,
         segment_id=0,
     )
-    workout_segment.duration = datetime.timedelta(seconds=6000)
+    workout_segment.duration = timedelta(seconds=6000)
     workout_segment.moving = workout_segment.duration
     workout_segment.distance = 5
     db.session.add(workout_segment)
@@ -142,9 +142,9 @@ def workout_running_user_1() -> Workout:
         user_id=1,
         sport_id=2,
         # workout_date: 'Mon, 02 Apr 2018 00:00:00 GMT'
-        workout_date=datetime.datetime.strptime('02/04/2018', '%d/%m/%Y'),
+        workout_date=datetime(2018, 4, 2, tzinfo=timezone.utc),
         distance=12,
-        duration=datetime.timedelta(seconds=6000),
+        duration=timedelta(seconds=6000),
     )
     update_workout(workout)
     db.session.add(workout)
@@ -159,11 +159,9 @@ def seven_workouts_user_1() -> List[Workout]:
         user_id=1,
         sport_id=1,
         # workout_date: 'Sun, 2 Apr 2017 22:00:00 GMT'
-        workout_date=datetime.datetime.strptime(
-            '02/04/2017 22:00', '%d/%m/%Y %H:%M'
-        ),
+        workout_date=datetime(2017, 4, 2, 22, tzinfo=timezone.utc),
         distance=5,
-        duration=datetime.timedelta(seconds=1024),
+        duration=timedelta(seconds=1024),
     )
     workout_1.title = "Workout 1 of 7"
     update_workout(workout_1)
@@ -177,11 +175,9 @@ def seven_workouts_user_1() -> List[Workout]:
         user_id=1,
         sport_id=1,
         # workout_date: 'Sun, 31 Dec 2017 23:00:00 GMT'
-        workout_date=datetime.datetime.strptime(
-            '31/12/2017 23:00', '%d/%m/%Y %H:%M'
-        ),
+        workout_date=datetime(2017, 12, 31, 23, tzinfo=timezone.utc),
         distance=10,
-        duration=datetime.timedelta(seconds=3456),
+        duration=timedelta(seconds=3456),
     )
     workout_2.title = "Workout 2 of 7"
     update_workout(workout_2)
@@ -195,9 +191,9 @@ def seven_workouts_user_1() -> List[Workout]:
         user_id=1,
         sport_id=1,
         # workout_date: 'Mon, 01 Jan 2018 00:00:00 GMT'
-        workout_date=datetime.datetime.strptime('01/01/2018', '%d/%m/%Y'),
+        workout_date=datetime(2018, 1, 1, tzinfo=timezone.utc),
         distance=10,
-        duration=datetime.timedelta(seconds=1024),
+        duration=timedelta(seconds=1024),
     )
     workout_3.title = "Workout 3 of 7"
     update_workout(workout_3)
@@ -211,11 +207,9 @@ def seven_workouts_user_1() -> List[Workout]:
         user_id=1,
         sport_id=1,
         # workout_date: 'Fri, 23 Feb 2018 10:00:00 GMT'
-        workout_date=datetime.datetime.strptime(
-            '23/02/2018 10:00', '%d/%m/%Y %H:%M'
-        ),
+        workout_date=datetime(2018, 2, 23, 10, tzinfo=timezone.utc),
         distance=1,
-        duration=datetime.timedelta(seconds=600),
+        duration=timedelta(seconds=600),
     )
     workout_4.title = "Workout 4 of 7"
     update_workout(workout_4)
@@ -229,9 +223,9 @@ def seven_workouts_user_1() -> List[Workout]:
         user_id=1,
         sport_id=1,
         # workout_date: 'Fri, 23 Feb 2018 00:00:00 GMT'
-        workout_date=datetime.datetime.strptime('23/02/2018', '%d/%m/%Y'),
+        workout_date=datetime(2018, 2, 23, tzinfo=timezone.utc),
         distance=10,
-        duration=datetime.timedelta(seconds=1000),
+        duration=timedelta(seconds=1000),
     )
     workout_5.title = "Workout 5 of 7"
     update_workout(workout_5)
@@ -245,9 +239,9 @@ def seven_workouts_user_1() -> List[Workout]:
         user_id=1,
         sport_id=1,
         # workout_date: 'Sun, 01 Apr 2018 00:00:00 GMT'
-        workout_date=datetime.datetime.strptime('01/04/2018', '%d/%m/%Y'),
+        workout_date=datetime(2018, 4, 1, tzinfo=timezone.utc),
         distance=8,
-        duration=datetime.timedelta(seconds=6000),
+        duration=timedelta(seconds=6000),
     )
     workout_6.title = "Workout 6 of 7"
     update_workout(workout_6)
@@ -261,12 +255,12 @@ def seven_workouts_user_1() -> List[Workout]:
         user_id=1,
         sport_id=1,
         # workout_date: 'Wed, 09 May 2018 00:00:00 GMT'
-        workout_date=datetime.datetime.strptime('09/05/2018', '%d/%m/%Y'),
+        workout_date=datetime(2018, 5, 9, tzinfo=timezone.utc),
         distance=10,
-        duration=datetime.timedelta(seconds=3600),
+        duration=timedelta(seconds=3600),
     )
     workout_7.title = "Workout 7 of 7"
-    workout_7.moving = datetime.timedelta(seconds=3000)
+    workout_7.moving = timedelta(seconds=3000)
     workout_7.ave_speed = float(workout_7.distance) / (
         workout_7.moving.seconds / 3600
     )
@@ -282,18 +276,16 @@ def seven_workouts_user_1() -> List[Workout]:
 def three_workouts_2025_user_1() -> List[Workout]:
     workouts = []
     for workout_date in [
-        '01/01/2025 08:00',
-        '05/01/2025 08:00',
-        '06/01/2025 08:00',
+        datetime(2025, 1, 1, tzinfo=timezone.utc),
+        datetime(2025, 1, 5, tzinfo=timezone.utc),
+        datetime(2025, 1, 6, tzinfo=timezone.utc),
     ]:
         workout = Workout(
             user_id=1,
             sport_id=1,
-            workout_date=datetime.datetime.strptime(
-                workout_date, '%d/%m/%Y %H:%M'
-            ),
+            workout_date=workout_date,
             distance=20,
-            duration=datetime.timedelta(seconds=3600),
+            duration=timedelta(seconds=3600),
         )
         update_workout(workout)
         db.session.add(workout)
@@ -309,9 +301,9 @@ def workout_cycling_user_2() -> Workout:
         user_id=2,
         sport_id=1,
         # workout_date: 'Tue, 23 Jan 2018 00:00:00 GMT'
-        workout_date=datetime.datetime.strptime('23/01/2018', '%d/%m/%Y'),
+        workout_date=datetime(2018, 1, 23, tzinfo=timezone.utc),
         distance=15,
-        duration=datetime.timedelta(seconds=3600),
+        duration=timedelta(seconds=3600),
     )
     update_workout(workout)
     db.session.add(workout)

--- a/fittrackee/tests/mixins.py
+++ b/fittrackee/tests/mixins.py
@@ -1,6 +1,6 @@
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple, Union
 from unittest.mock import Mock
 from urllib.parse import parse_qs
@@ -446,7 +446,9 @@ class ReportMixin(RandomMixin):
             admin, user, action_type=action_type, report_id=report_id
         )
         user.suspended_at = (
-            datetime.utcnow() if action_type == "user_suspension" else None
+            datetime.now(timezone.utc)
+            if action_type == "user_suspension"
+            else None
         )
         db.session.commit()
         return report_action
@@ -488,7 +490,9 @@ class ReportMixin(RandomMixin):
         )
         db.session.add(report_action)
         comment.suspended_at = (
-            datetime.utcnow() if action_type == "comment_suspension" else None
+            datetime.now(timezone.utc)
+            if action_type == "comment_suspension"
+            else None
         )
         return report_action
 

--- a/fittrackee/tests/oauth2/test_oauth2_routes.py
+++ b/fittrackee/tests/oauth2/test_oauth2_routes.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple, Union
 from unittest.mock import patch
 
@@ -240,7 +240,7 @@ class TestOAuthClientAuthorization(ApiTestCaseMixin):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
 
         response = client.post(
             self.route,
@@ -656,7 +656,7 @@ class TestOAuthIssueAccessToken(OAuthIssueTokenTestCase):
     ) -> None:
         oauth_client, code = self.create_authorized_oauth_client(app, user_1)
         client = app.test_client()
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
 
         response = client.post(
             self.route,
@@ -806,7 +806,7 @@ class TestOAuthIssueRefreshToken(OAuthIssueTokenTestCase):
     ) -> None:
         oauth_client, token = self.generate_token(app, user_1)
         client = app.test_client()
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
 
         response = client.post(
             self.route,
@@ -883,7 +883,7 @@ class TestOAuthTokenRevocation(ApiTestCaseMixin):
             access_token,
             _,
         ) = self.create_oauth2_client_and_issue_token(app, user_1)
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
 
         response = client.post(
             self.route,

--- a/fittrackee/tests/reports/test_report_actions_model.py
+++ b/fittrackee/tests/reports/test_report_actions_model.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict
 
 import pytest
@@ -57,7 +57,7 @@ class TestReportActionForReportModel(ReportActionTestCase):
         input_action_type: str,
     ) -> None:
         report = self.create_report(reporter=user_2, reported_object=user_3)
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
 
         report_action = ReportAction(
             action_type=input_action_type,
@@ -85,7 +85,7 @@ class TestReportActionForReportModel(ReportActionTestCase):
         user_3: User,
     ) -> None:
         report = self.create_report(reporter=user_2, reported_object=user_3)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         action_type = "report_resolution"
 
         with travel(now, tick=False):
@@ -109,7 +109,7 @@ class TestReportActionForReportModel(ReportActionTestCase):
     def test_it_does_not_store_user_id_when_action_is_for_report(
         self, app: Flask, user_1_admin: User, user_2: User, user_3: User
     ) -> None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report = self.create_report(reporter=user_2, reported_object=user_3)
         action_type = "report_resolution"
 
@@ -167,7 +167,7 @@ class TestReportActionForUserModel(ReportActionTestCase):
             ReportAction(
                 action_type=input_action_type,
                 moderator_id=user_1_admin.id,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
                 report_id=self.create_report(
                     reporter=user_1_admin, reported_object=user_2
                 ).id,
@@ -177,7 +177,7 @@ class TestReportActionForUserModel(ReportActionTestCase):
         self, app: Flask, user_1_admin: User, user_2: User, user_3: User
     ) -> None:
         report = self.create_report(reporter=user_2, reported_object=user_3)
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
 
         report_action = ReportAction(
             action_type="user_suspension",
@@ -205,7 +205,7 @@ class TestReportActionForUserModel(ReportActionTestCase):
             reporter=user_1_admin, reported_object=user_2
         ).id
         action_type = "user_suspension"
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report_action = ReportAction(
             action_type=action_type,
             moderator_id=user_1_admin.id,
@@ -263,7 +263,7 @@ class TestReportActionForWorkoutModel(ReportActionTestCase):
             ReportAction(
                 action_type=input_action_type,
                 moderator_id=user_1_admin.id,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
                 report_id=self.create_report(
                     reporter=user_1_admin,
                     reported_object=workout_cycling_user_2,
@@ -285,7 +285,7 @@ class TestReportActionForWorkoutModel(ReportActionTestCase):
             ReportAction(
                 action_type=input_action_type,
                 moderator_id=user_1_admin.id,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
                 report_id=self.create_report(
                     reporter=user_1_admin,
                     reported_object=workout_cycling_user_2,
@@ -305,7 +305,7 @@ class TestReportActionForWorkoutModel(ReportActionTestCase):
         report_id = self.create_report(
             reporter=user_3, reported_object=workout_cycling_user_2
         ).id
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
 
         report_action = ReportAction(
             action_type="workout_suspension",
@@ -338,7 +338,7 @@ class TestReportActionForWorkoutModel(ReportActionTestCase):
         report_id = self.create_report(
             reporter=user_1_admin, reported_object=workout_cycling_user_2
         ).id
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
         report_action = ReportAction(
             action_type="workout_suspension",
             moderator_id=user_1_admin.id,
@@ -373,7 +373,7 @@ class TestReportActionForWorkoutModel(ReportActionTestCase):
         report_id = self.create_report(
             reporter=user_1_admin, reported_object=workout_cycling_user_2
         ).id
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
         report_action = ReportAction(
             action_type="workout_suspension",
             moderator_id=user_1_admin.id,
@@ -423,7 +423,7 @@ class TestReportActionForCommentsModel(CommentMixin, ReportActionTestCase):
             ReportAction(
                 action_type=input_action_type,
                 moderator_id=user_1_admin.id,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
                 report_id=report_id,
                 user_id=user_2.id,
             )
@@ -453,7 +453,7 @@ class TestReportActionForCommentsModel(CommentMixin, ReportActionTestCase):
                 report_id=self.create_report(
                     reporter=user_2, reported_object=comment
                 ).id,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
             )
 
     def test_it_creates_comment_report_action(
@@ -474,7 +474,7 @@ class TestReportActionForCommentsModel(CommentMixin, ReportActionTestCase):
         report_id = self.create_report(
             reporter=user_2, reported_object=comment
         ).id
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
 
         report_action = ReportAction(
             action_type="comment_suspension",
@@ -514,7 +514,7 @@ class TestReportActionForCommentsModel(CommentMixin, ReportActionTestCase):
         report_id = self.create_report(
             reporter=user_2, reported_object=comment
         ).id
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
         report_action = ReportAction(
             action_type="comment_suspension",
             moderator_id=user_1_admin.id,
@@ -556,7 +556,7 @@ class TestReportActionForCommentsModel(CommentMixin, ReportActionTestCase):
         report_id = self.create_report(
             reporter=user_2, reported_object=comment
         ).id
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
         report_action = ReportAction(
             action_type="comment_suspension",
             moderator_id=user_1_admin.id,
@@ -1051,7 +1051,7 @@ class TestReportActionAppealModel(CommentMixin, ReportActionTestCase):
     ) -> None:
         appeal_text = self.random_string()
         report_action = self.create_report_user_action(user_1_admin, user_2)
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
 
         appeal = ReportActionAppeal(
             action_id=report_action.id,
@@ -1078,7 +1078,7 @@ class TestReportActionAppealModel(CommentMixin, ReportActionTestCase):
         report_action = self.create_report_user_action(
             user_1_admin, user_2, action_type="user_warning"
         )
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
 
         appeal = ReportActionAppeal(
             action_id=report_action.id,
@@ -1133,7 +1133,7 @@ class TestReportActionAppealModel(CommentMixin, ReportActionTestCase):
         )
         db.session.add(report_action)
         appeal_text = self.random_string()
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
         db.session.flush()
 
         appeal = ReportActionAppeal(
@@ -1197,7 +1197,7 @@ class TestReportActionAppealModel(CommentMixin, ReportActionTestCase):
         )
         db.session.add(report_action)
         appeal_text = self.random_string()
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
         db.session.flush()
 
         appeal = ReportActionAppeal(
@@ -1223,7 +1223,7 @@ class TestReportActionAppealModel(CommentMixin, ReportActionTestCase):
     ) -> None:
         appeal_text = self.random_string()
         report_action = self.create_report_user_action(user_1_admin, user_2)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             appeal = ReportActionAppeal(

--- a/fittrackee/tests/reports/test_reports_api.py
+++ b/fittrackee/tests/reports/test_reports_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List
 from unittest.mock import MagicMock, patch
 
@@ -270,7 +270,7 @@ class TestPostCommentReport(ReportTestCase):
             workout_cycling_user_1,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
@@ -541,7 +541,7 @@ class TestPostWorkoutReport(ReportTestCase):
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -789,7 +789,7 @@ class TestPostUserReport(ReportTestCase):
         sport_1_cycling: Sport,
         workout_cycling_user_2: Workout,
     ) -> None:
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -1348,7 +1348,7 @@ class TestGetReportsAsModerator(ReportTestCase):
         reports = self.create_reports(
             user_2, user_3, user_4, workout_cycling_user_2
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         reports[1].updated_at = now
         reports[0].updated_at = now + timedelta(minutes=1)
         db.session.commit()
@@ -1422,7 +1422,7 @@ class TestGetReportsAsModerator(ReportTestCase):
         reports = self.create_reports(
             user_2, user_3, user_4, workout_cycling_user_2
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         reports[1].updated_at = now
         reports[0].updated_at = now + timedelta(minutes=1)
         db.session.commit()
@@ -1937,7 +1937,7 @@ class TestPatchReport(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         comment = self.random_string()
 
         with travel(now, tick=False):
@@ -1971,7 +1971,7 @@ class TestPatchReport(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         comment = self.random_string()
 
         with travel(now, tick=False):
@@ -2000,13 +2000,13 @@ class TestPatchReport(ReportTestCase):
     ) -> None:
         report = self.create_report(reporter=user_3, reported_object=user_2)
         report.resolved = True
-        report.resolved_at = datetime.utcnow()
+        report.resolved_at = datetime.now(timezone.utc)
         report.resolved_by = user_1_moderator.id
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         comment = self.random_string()
 
         with travel(now, tick=False):
@@ -2038,14 +2038,14 @@ class TestPatchReport(ReportTestCase):
             reporter=user_3, reported_object=user_2_admin
         )
         report.resolved = True
-        resolved_time = datetime.utcnow()
+        resolved_time = datetime.now(timezone.utc)
         report.resolved_at = resolved_time
         report.resolved_by = user_2_admin.id
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        comment_time = datetime.utcnow()
+        comment_time = datetime.now(timezone.utc)
         comment = self.random_string()
 
         with travel(comment_time, tick=False):
@@ -2268,7 +2268,7 @@ class TestPostReportActionForUserAction(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             response = client.post(
@@ -2294,7 +2294,7 @@ class TestPostReportActionForUserAction(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
 
         response = client.post(
@@ -2340,7 +2340,7 @@ class TestPostReportActionForUserAction(ReportTestCase):
         self, app: Flask, user_1_moderator: User, user_2: User, user_3: User
     ) -> None:
         report = self.create_report(reporter=user_3, reported_object=user_2)
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
@@ -2373,7 +2373,7 @@ class TestPostReportActionForUserAction(ReportTestCase):
     ) -> None:
         report = self.create_report(reporter=user_3, reported_object=user_2)
         if input_action_type == "user_unsuspension":
-            user_2.suspended_at = datetime.utcnow()
+            user_2.suspended_at = datetime.now(timezone.utc)
             db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
@@ -2509,7 +2509,7 @@ class TestPostReportActionForUserAction(ReportTestCase):
         user_unsuspension_email_mock: MagicMock,
     ) -> None:
         report = self.create_report(reporter=user_3, reported_object=user_2)
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
@@ -2684,7 +2684,7 @@ class TestPostReportActionForWorkoutAction(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             response = client.post(
@@ -2721,7 +2721,7 @@ class TestPostReportActionForWorkoutAction(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
 
         response = client.post(
@@ -2755,7 +2755,7 @@ class TestPostReportActionForWorkoutAction(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
 
         response = client.post(
             self.route.format(report_id=report.id),
@@ -2890,7 +2890,7 @@ class TestPostReportActionForWorkoutAction(ReportTestCase):
         report = self.create_report(
             reporter=user_3, reported_object=workout_cycling_user_2
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
@@ -3048,7 +3048,7 @@ class TestPostReportActionForCommentAction(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             response = client.post(
@@ -3083,9 +3083,9 @@ class TestPostReportActionForCommentAction(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             response = client.post(
@@ -3120,7 +3120,7 @@ class TestPostReportActionForCommentAction(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
 
         response = client.post(
             self.route.format(report_id=report.id),
@@ -3190,7 +3190,7 @@ class TestPostReportActionForCommentAction(ReportTestCase):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             response = client.post(
@@ -3266,7 +3266,7 @@ class TestPostReportActionForCommentAction(ReportTestCase):
             with_mentions=True,
         )
         report = self.create_report(reporter=user_2, reported_object=comment)
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
@@ -3787,14 +3787,14 @@ class TestProcessReportActionAppeal(
         suspension_action = self.create_report_workout_action(
             user_1_moderator, user_2, workout_cycling_user_2
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         appeal = self.create_action_appeal(suspension_action.id, user_2)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             response = client.patch(
@@ -3825,7 +3825,7 @@ class TestProcessReportActionAppeal(
         suspension_action = self.create_report_workout_action(
             user_1_moderator, user_2, workout_cycling_user_2
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         appeal = self.create_action_appeal(suspension_action.id, user_2)
         db.session.commit()
@@ -3854,7 +3854,7 @@ class TestProcessReportActionAppeal(
         suspension_action = self.create_report_workout_action(
             user_1_moderator, user_2, workout_cycling_user_2
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         appeal = self.create_action_appeal(suspension_action.id, user_2)
         db.session.commit()
@@ -3882,7 +3882,7 @@ class TestProcessReportActionAppeal(
         suspension_action = self.create_report_workout_action(
             user_1_moderator, user_2, workout_cycling_user_2
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         appeal = self.create_action_appeal(suspension_action.id, user_2)
         db.session.commit()

--- a/fittrackee/tests/reports/test_reports_email_service.py
+++ b/fittrackee/tests/reports/test_reports_email_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict
 from unittest.mock import MagicMock
 
@@ -70,7 +70,7 @@ class TestReportEmailServiceForUserReactivation(
         report = self.create_report_for_user(
             report_service, reporter=user_2, reported_user=user_3
         )
-        user_3.suspended_at = datetime.utcnow()
+        user_3.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         report_email_service = ReportEmailService()
 
@@ -109,7 +109,7 @@ class TestReportEmailServiceForUserWarning(
         report = self.create_report_for_user(
             report_service, reporter=user_2, reported_user=user_3
         )
-        user_3.suspended_at = datetime.utcnow()
+        user_3.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         report_email_service = ReportEmailService()
         user_warning = report_service.create_report_action(
@@ -388,7 +388,7 @@ class TestReportEmailServiceForUserWarningLifting(
         report = self.create_report_for_user(
             report_service, reporter=user_2, reported_user=user_3
         )
-        user_3.suspended_at = datetime.utcnow()
+        user_3.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         report_email_service = ReportEmailService()
         user_warning = report_service.create_report_action(
@@ -696,7 +696,7 @@ class TestReportEmailServiceForComment(ReportServiceCreateReportActionMixin):
             commenter=user_3,
             workout=workout_cycling_user_2,
         )
-        report.reported_comment.suspended_at = datetime.utcnow()
+        report.reported_comment.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         report_email_service = ReportEmailService()
 
@@ -744,7 +744,7 @@ class TestReportEmailServiceForComment(ReportServiceCreateReportActionMixin):
             commenter=user_3,
             workout=workout_cycling_user_2,
         )
-        report.reported_comment.suspended_at = datetime.utcnow()
+        report.reported_comment.suspended_at = datetime.now(timezone.utc)
         db.session.delete(workout_cycling_user_2)
         db.session.flush()
         report_email_service = ReportEmailService()
@@ -890,7 +890,7 @@ class TestReportEmailServiceForWorkout(ReportServiceCreateReportActionMixin):
             reporter=user_3,
             workout=workout_cycling_user_2,
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         report_email_service = ReportEmailService()
 
@@ -938,7 +938,7 @@ class TestReportEmailServiceForWorkout(ReportServiceCreateReportActionMixin):
             reporter=user_3,
             workout=workout_cycling_user_2,
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         report_email_service = ReportEmailService()
 
@@ -1034,7 +1034,7 @@ class TestReportEmailServiceForAppealRejected(
             reporter=user_3,
             workout=workout_cycling_user_2,
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         report_action = self.create_report_workout_action(
             user_1_moderator, user_3, workout_cycling_user_2

--- a/fittrackee/tests/reports/test_reports_email_service.py
+++ b/fittrackee/tests/reports/test_reports_email_service.py
@@ -6,10 +6,10 @@ import pytest
 from flask import Flask
 
 from fittrackee import db
+from fittrackee.dates import get_date_string_for_user
 from fittrackee.reports.reports_email_service import ReportEmailService
 from fittrackee.reports.reports_service import ReportService
 from fittrackee.users.models import User
-from fittrackee.utils import get_date_string_for_user
 from fittrackee.workouts.models import Sport, Workout
 
 from ..mixins import ReportMixin

--- a/fittrackee/tests/reports/test_reports_model.py
+++ b/fittrackee/tests/reports/test_reports_model.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from flask import Flask
@@ -40,7 +40,7 @@ class TestReportModel(CommentMixin, RandomMixin):
         user_2: User,
     ) -> None:
         workout_cycling_user_1.workout_visibility = VisibilityLevel.PUBLIC
-        report_created_at = datetime.utcnow()
+        report_created_at = datetime.now(timezone.utc)
         report_note = self.random_string()
         comment = self.create_comment(
             user_2,
@@ -77,7 +77,7 @@ class TestReportModel(CommentMixin, RandomMixin):
         user_2: User,
     ) -> None:
         workout_cycling_user_1.workout_visibility = VisibilityLevel.PUBLIC
-        report_created_at = datetime.utcnow()
+        report_created_at = datetime.now(timezone.utc)
         report_note = self.random_string()
         comment = self.create_comment(
             user_2,
@@ -116,7 +116,7 @@ class TestReportModel(CommentMixin, RandomMixin):
         user_1: User,
         user_2: User,
     ) -> None:
-        report_created_at = datetime.utcnow()
+        report_created_at = datetime.now(timezone.utc)
         report_note = self.random_string()
 
         report = Report(
@@ -145,7 +145,7 @@ class TestReportModel(CommentMixin, RandomMixin):
         user_1: User,
         user_2: User,
     ) -> None:
-        report_created_at = datetime.utcnow()
+        report_created_at = datetime.now(timezone.utc)
         report_note = self.random_string()
         report = Report(
             created_at=report_created_at,
@@ -179,7 +179,7 @@ class TestReportModel(CommentMixin, RandomMixin):
         user_1: User,
         user_2: User,
     ) -> None:
-        report_created_at = datetime.utcnow()
+        report_created_at = datetime.now(timezone.utc)
         report_note = self.random_string()
         report = Report(
             created_at=report_created_at,
@@ -216,7 +216,7 @@ class TestReportModel(CommentMixin, RandomMixin):
         workout_cycling_user_2: Workout,
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
-        report_created_at = datetime.utcnow()
+        report_created_at = datetime.now(timezone.utc)
         report_note = self.random_string()
 
         report = Report(
@@ -248,7 +248,7 @@ class TestReportModel(CommentMixin, RandomMixin):
         workout_cycling_user_2: Workout,
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
-        report_created_at = datetime.utcnow()
+        report_created_at = datetime.now(timezone.utc)
         report_note = self.random_string()
         report = Report(
             created_at=report_created_at,
@@ -279,7 +279,7 @@ class TestReportModel(CommentMixin, RandomMixin):
     def test_it_creates_report_without_date(
         self, app: Flask, user_1: User, user_2: User
     ) -> None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report_note = self.random_string()
 
         with travel(now, tick=False):
@@ -1141,7 +1141,7 @@ class TestReportCommentModel(ReportCommentTestCase):
         self, app: Flask, user_1_moderator: User, user_2: User, user_3: User
     ) -> None:
         report = self.create_report(reporter=user_2, reported_object=user_3)
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
         comment = self.random_string()
 
         report_comment = ReportComment(
@@ -1163,7 +1163,7 @@ class TestReportCommentModel(ReportCommentTestCase):
     ) -> None:
         report = self.create_report(reporter=user_2, reported_object=user_3)
         comment = self.random_string()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_comment = ReportComment(

--- a/fittrackee/tests/reports/test_reports_service.py
+++ b/fittrackee/tests/reports/test_reports_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict
 
 import pytest
@@ -115,7 +115,7 @@ class TestReportServiceCreateForComment(CommentMixin):
             text_visibility=VisibilityLevel.PUBLIC,
         )
         note = self.random_string()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report_service = ReportService()
         # report from another user
         report_service.create_report(
@@ -199,7 +199,7 @@ class TestReportServiceCreateForComment(CommentMixin):
             workout_cycling_user_2,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        comment.suspended_at = datetime.utcnow()
+        comment.suspended_at = datetime.now(timezone.utc)
         report_service = ReportService()
 
         with pytest.raises(
@@ -275,7 +275,7 @@ class TestReportServiceCreateForWorkout(RandomMixin):
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
         note = self.random_string()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report_service = ReportService()
         # report from another user
         report_service.create_report(
@@ -351,7 +351,7 @@ class TestReportServiceCreateForWorkout(RandomMixin):
         workout_cycling_user_2: Workout,
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         report_service = ReportService()
 
         with pytest.raises(
@@ -409,7 +409,7 @@ class TestReportServiceCreateForUser(RandomMixin):
         self, app: Flask, user_1: User, user_2: User, user_3: User
     ) -> None:
         note = self.random_string()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report_service = ReportService()
         # report from another user
         report_service.create_report(
@@ -482,7 +482,7 @@ class TestReportServiceCreateForUser(RandomMixin):
         sport_1_cycling: Sport,
         workout_cycling_user_2: Workout,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         report_service = ReportService()
 
         with pytest.raises(
@@ -521,7 +521,7 @@ class TestReportServiceUpdate(CommentMixin):
             object_type="user",
         )
         created_at = report.created_at
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             updated_report = report_service.update_report(
@@ -553,7 +553,7 @@ class TestReportServiceUpdate(CommentMixin):
             object_type="user",
         )
         comment = self.random_string()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.update_report(
@@ -600,7 +600,7 @@ class TestReportServiceUpdate(CommentMixin):
             object_type="user",
         )
         created_at = report.created_at
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             updated_report = report_service.update_report(
@@ -632,7 +632,7 @@ class TestReportServiceUpdate(CommentMixin):
             object_id=user_3.username,
             object_type="user",
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.update_report(
@@ -663,9 +663,9 @@ class TestReportServiceUpdate(CommentMixin):
         )
         created_at = report.created_at
         report.resolved = True
-        report.resolved_at = datetime.utcnow()
+        report.resolved_at = datetime.now(timezone.utc)
         report.resolved_by = user_1_admin.id
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             updated_report = report_service.update_report(
@@ -698,9 +698,9 @@ class TestReportServiceUpdate(CommentMixin):
             object_type="user",
         )
         report.resolved = True
-        report.resolved_at = datetime.utcnow()
+        report.resolved_at = datetime.now(timezone.utc)
         report.resolved_by = user_1_admin.id
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.update_report(
@@ -729,7 +729,7 @@ class TestReportServiceUpdate(CommentMixin):
             object_type="user",
         )
 
-        with travel(datetime.utcnow(), tick=False):
+        with travel(datetime.now(timezone.utc), tick=False):
             report_service.update_report(
                 report_id=report.id,
                 moderator=user_1_admin,
@@ -751,7 +751,7 @@ class TestReportServiceUpdate(CommentMixin):
             object_type="user",
         )
         created_at = report.created_at
-        resolved_time = datetime.utcnow()
+        resolved_time = datetime.now(timezone.utc)
 
         # resolved by user_1_admin
         with travel(resolved_time, tick=False):
@@ -872,7 +872,7 @@ class TestReportServiceCreateReportActionForUser(
         report = self.create_report_for_user(
             report_service, reporter=user_2, reported_user=user_3
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -895,7 +895,7 @@ class TestReportServiceCreateReportActionForUser(
         report = self.create_report_for_user(
             report_service, reporter=user_2, reported_user=user_3
         )
-        user_3.suspended_at = datetime.utcnow()
+        user_3.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
 
         with pytest.raises(
@@ -917,7 +917,7 @@ class TestReportServiceCreateReportActionForUser(
         report = self.create_report_for_user(
             report_service, reporter=user_2, reported_user=user_3
         )
-        user_3.suspended_at = datetime.utcnow()
+        user_3.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
 
         report_service.create_report_action(
@@ -973,7 +973,7 @@ class TestReportServiceCreateReportActionForUser(
         )
         db.session.add(another_user_suspension)
         db.session.flush()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1002,7 +1002,7 @@ class TestReportServiceCreateReportActionForUser(
         report = self.create_report_for_user(
             report_service, reporter=user_2, reported_user=user_3
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1032,7 +1032,7 @@ class TestReportServiceCreateReportActionForUser(
         report = self.create_report_for_user(
             report_service, reporter=user_2, reported_user=user_3
         )
-        user_3.suspended_at = datetime.utcnow()
+        user_3.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
 
         report_service.create_report_action(
@@ -1286,7 +1286,7 @@ class TestReportServiceCreateReportActionForComment(
             commenter=user_3,
             workout=workout_cycling_user_2,
         )
-        report.reported_comment.suspended_at = datetime.utcnow()
+        report.reported_comment.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
 
         with pytest.raises(
@@ -1316,7 +1316,7 @@ class TestReportServiceCreateReportActionForComment(
             commenter=user_3,
             workout=workout_cycling_user_2,
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1351,7 +1351,7 @@ class TestReportServiceCreateReportActionForComment(
             commenter=user_3,
             workout=workout_cycling_user_2,
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1389,9 +1389,9 @@ class TestReportServiceCreateReportActionForComment(
             commenter=user_3,
             workout=workout_cycling_user_2,
         )
-        report.reported_comment.suspended_at = datetime.utcnow()
+        report.reported_comment.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1453,9 +1453,9 @@ class TestReportServiceCreateReportActionForComment(
             commenter=user_3,
             workout=workout_cycling_user_2,
         )
-        report.reported_comment.suspended_at = datetime.utcnow()
+        report.reported_comment.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1500,10 +1500,10 @@ class TestReportServiceCreateReportActionForComment(
             comment_id=report.reported_comment_id,
         )
         db.session.add(comment_suspension)
-        report.reported_comment.suspended_at = datetime.utcnow()
+        report.reported_comment.suspended_at = datetime.now(timezone.utc)
         appeal = self.create_action_appeal(comment_suspension.id, user_3)
         db.session.flush()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1588,7 +1588,7 @@ class TestReportServiceCreateReportActionForWorkout(
             reporter=user_3,
             workout=workout_cycling_user_2,
         )
-        report.reported_workout.suspended_at = datetime.utcnow()
+        report.reported_workout.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
 
         with pytest.raises(
@@ -1617,7 +1617,7 @@ class TestReportServiceCreateReportActionForWorkout(
             reporter=user_3,
             workout=workout_cycling_user_2,
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1651,7 +1651,7 @@ class TestReportServiceCreateReportActionForWorkout(
             reporter=user_3,
             workout=workout_cycling_user_2,
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1688,9 +1688,9 @@ class TestReportServiceCreateReportActionForWorkout(
             reporter=user_3,
             workout=workout_cycling_user_2,
         )
-        report.reported_workout.suspended_at = datetime.utcnow()
+        report.reported_workout.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1751,9 +1751,9 @@ class TestReportServiceCreateReportActionForWorkout(
             reporter=user_3,
             workout=workout_cycling_user_2,
         )
-        report.reported_workout.suspended_at = datetime.utcnow()
+        report.reported_workout.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1797,10 +1797,10 @@ class TestReportServiceCreateReportActionForWorkout(
             workout_id=report.reported_workout_id,
         )
         db.session.add(workout_suspension)
-        report.reported_workout.suspended_at = datetime.utcnow()
+        report.reported_workout.suspended_at = datetime.now(timezone.utc)
         appeal = self.create_action_appeal(workout_suspension.id, user_2)
         db.session.flush()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.create_report_action(
@@ -1832,7 +1832,7 @@ class TestReportServiceProcessAppeal(
         )
         appeal = self.create_action_appeal(suspension_action.id, user_2)
         report_service = ReportService()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.process_appeal(
@@ -1860,7 +1860,7 @@ class TestReportServiceProcessAppeal(
         )
         appeal = self.create_action_appeal(suspension_action.id, user_2)
         report_service = ReportService()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.process_appeal(
@@ -1882,7 +1882,7 @@ class TestReportServiceProcessAppeal(
         )
         appeal = self.create_action_appeal(suspension_action.id, user_2)
         report_service = ReportService()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.process_appeal(
@@ -1958,7 +1958,7 @@ class TestReportServiceProcessAppeal(
         )
         appeal = self.create_action_appeal(warning_action.id, user_2)
         report_service = ReportService()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.process_appeal(
@@ -1986,7 +1986,7 @@ class TestReportServiceProcessAppeal(
         )
         appeal = self.create_action_appeal(warning_action.id, user_2)
         report_service = ReportService()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.process_appeal(
@@ -2038,7 +2038,7 @@ class TestReportServiceProcessAppeal(
         appeal = self.create_action_appeal(suspension_action.id, user_3)
         db.session.commit()
         report_service = ReportService()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.process_appeal(
@@ -2190,13 +2190,13 @@ class TestReportServiceProcessAppeal(
         suspension_action = self.create_report_workout_action(
             user_1_admin, user_2, workout_cycling_user_2
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         workout_suspended_at = workout_cycling_user_2.suspended_at
         db.session.flush()
         appeal = self.create_action_appeal(suspension_action.id, user_2)
         db.session.commit()
         report_service = ReportService()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             report_service.process_appeal(
@@ -2228,7 +2228,7 @@ class TestReportServiceProcessAppeal(
         suspension_action = self.create_report_workout_action(
             user_1_admin, user_2, workout_cycling_user_2
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.flush()
         appeal = self.create_action_appeal(suspension_action.id, user_2)
         db.session.commit()

--- a/fittrackee/tests/test_all_utils.py
+++ b/fittrackee/tests/test_all_utils.py
@@ -4,14 +4,11 @@ from typing import Union
 import pytest
 from flask import Flask
 
+from fittrackee.dates import get_date_string_for_user, get_readable_duration
 from fittrackee.files import display_readable_file_size
 from fittrackee.request import UserAgent
 from fittrackee.users.models import User
-from fittrackee.utils import (
-    clean_input,
-    get_date_string_for_user,
-    get_readable_duration,
-)
+from fittrackee.utils import clean_input
 
 
 class TestDisplayReadableFileSize:

--- a/fittrackee/tests/test_utils.py
+++ b/fittrackee/tests/test_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Union
 
 import pytest
@@ -127,7 +127,7 @@ class TestSanitizeInput:
 
 class TestGetDateStringForUser:
     @pytest.mark.parametrize(
-        'language, date_format, timezone, expected_date_string',
+        'language, date_format, timezone_string, expected_date_string',
         [
             ('en', 'MM/dd/yyyy', 'America/New_York', '07/14/2024 - 07:32:47'),
             ('fr', 'dd/MM/yyyy', 'Europe/Paris', '14/07/2024 - 13:32:47'),
@@ -161,16 +161,22 @@ class TestGetDateStringForUser:
         user_1: 'User',
         language: Union[str, None],
         date_format: str,
-        timezone: Union[str, None],
+        timezone_string: Union[str, None],
         expected_date_string: str,
     ) -> None:
-        naive_datetime = datetime(
-            year=2024, month=7, day=14, hour=11, minute=32, second=47
+        datetime_in_utc = datetime(
+            year=2024,
+            month=7,
+            day=14,
+            hour=11,
+            minute=32,
+            second=47,
+            tzinfo=timezone.utc,
         )
         user_1.language = language
         user_1.date_format = date_format
-        user_1.timezone = timezone
+        user_1.timezone = timezone_string
 
-        date_string = get_date_string_for_user(naive_datetime, user_1)
+        date_string = get_date_string_for_user(datetime_in_utc, user_1)
 
         assert date_string == expected_date_string

--- a/fittrackee/tests/users/test_auth_api.py
+++ b/fittrackee/tests/users/test_auth_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from typing import Dict, Optional, Union
 from unittest.mock import MagicMock, Mock, patch
@@ -356,7 +356,7 @@ class TestUserRegistration(ApiTestCaseMixin):
         client = app.test_client()
         username = self.random_string()
         email = self.random_email()
-        accepted_policy_date = datetime.utcnow()
+        accepted_policy_date = datetime.now(timezone.utc)
 
         with travel(accepted_policy_date, tick=False):
             client.post(
@@ -2944,7 +2944,7 @@ class TestPasswordUpdate(ApiTestCaseMixin):
     def test_it_returns_error_if_token_is_expired(
         self, app: Flask, user_1: User
     ) -> None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         token = get_user_token(user_1.id, password_reset=True)
         client = app.test_client()
 
@@ -3383,7 +3383,7 @@ class TestUserLogout(ApiTestCaseMixin):
     def test_it_returns_error_when_token_is_expired(
         self, app: Flask, user_1: User
     ) -> None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
@@ -3497,7 +3497,7 @@ class TestUserPrivacyPolicyUpdate(ApiTestCaseMixin):
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
-        accepted_policy_date = datetime.utcnow()
+        accepted_policy_date = datetime.now(timezone.utc)
 
         with travel(accepted_policy_date, tick=False):
             response = client.post(
@@ -3518,7 +3518,7 @@ class TestUserPrivacyPolicyUpdate(ApiTestCaseMixin):
         client, auth_token = self.get_test_client_and_auth_token(
             app, suspended_user.email
         )
-        accepted_policy_date = datetime.utcnow()
+        accepted_policy_date = datetime.now(timezone.utc)
 
         with travel(accepted_policy_date, tick=False):
             response = client.post(
@@ -3632,7 +3632,8 @@ class TestPostUserDataExportRequest(ApiTestCaseMixin):
         export_expiration = app.config["DATA_EXPORT_EXPIRATION"]
         completed_export_request = UserDataExport(
             user_id=user_1.id,
-            created_at=datetime.utcnow() - timedelta(hours=export_expiration),
+            created_at=datetime.now(timezone.utc)
+            - timedelta(hours=export_expiration),
         )
         db.session.add(completed_export_request)
         completed_export_request.completed = True
@@ -3688,7 +3689,8 @@ class TestPostUserDataExportRequest(ApiTestCaseMixin):
         export_expiration = app.config["DATA_EXPORT_EXPIRATION"]
         completed_export_request = UserDataExport(
             user_id=user_1.id,
-            created_at=datetime.utcnow() - timedelta(hours=export_expiration),
+            created_at=datetime.now(timezone.utc)
+            - timedelta(hours=export_expiration),
         )
         db.session.add(completed_export_request)
         db.session.commit()
@@ -3713,7 +3715,8 @@ class TestPostUserDataExportRequest(ApiTestCaseMixin):
         export_expiration = app.config["DATA_EXPORT_EXPIRATION"]
         completed_export_request = UserDataExport(
             user_id=user_1.id,
-            created_at=datetime.utcnow() - timedelta(hours=export_expiration),
+            created_at=datetime.now(timezone.utc)
+            - timedelta(hours=export_expiration),
         )
         db.session.add(completed_export_request)
         completed_export_request.completed = True
@@ -3791,7 +3794,8 @@ class TestGetUserDataExportRequest(ApiTestCaseMixin):
         export_expiration = app.config["DATA_EXPORT_EXPIRATION"]
         completed_export_request = UserDataExport(
             user_id=user_2.id,
-            created_at=datetime.utcnow() - timedelta(hours=export_expiration),
+            created_at=datetime.now(timezone.utc)
+            - timedelta(hours=export_expiration),
         )
         db.session.add(completed_export_request)
         db.session.commit()
@@ -3818,7 +3822,8 @@ class TestGetUserDataExportRequest(ApiTestCaseMixin):
         export_expiration = app.config["DATA_EXPORT_EXPIRATION"]
         completed_export_request = UserDataExport(
             user_id=user_1.id,
-            created_at=datetime.utcnow() - timedelta(hours=export_expiration),
+            created_at=datetime.now(timezone.utc)
+            - timedelta(hours=export_expiration),
         )
         db.session.add(completed_export_request)
         db.session.commit()
@@ -3847,7 +3852,8 @@ class TestGetUserDataExportRequest(ApiTestCaseMixin):
         export_expiration = app.config["DATA_EXPORT_EXPIRATION"]
         completed_export_request = UserDataExport(
             user_id=suspended_user.id,
-            created_at=datetime.utcnow() - timedelta(hours=export_expiration),
+            created_at=datetime.now(timezone.utc)
+            - timedelta(hours=export_expiration),
         )
         db.session.add(completed_export_request)
         db.session.commit()
@@ -4210,7 +4216,7 @@ class TestGetUserSuspension(UserSuspensionTestCase):
         self, app: Flask, user_1_admin: User, user_2: User
     ) -> None:
         action = self.create_report_user_action(user_1_admin, user_2)
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_2.email
@@ -4295,7 +4301,7 @@ class TestPostUserSuspensionAppeal(UserSuspensionTestCase):
         self, app: Flask, user_1_admin: User, user_2: User, input_data: Dict
     ) -> None:
         self.create_report_user_action(user_1_admin, user_2)
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_2.email
@@ -4314,13 +4320,13 @@ class TestPostUserSuspensionAppeal(UserSuspensionTestCase):
         self, app: Flask, user_1_admin: User, user_2: User
     ) -> None:
         action = self.create_report_user_action(user_1_admin, user_2)
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_2.email
         )
         text = self.random_string()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             response = client.post(
@@ -4345,7 +4351,7 @@ class TestPostUserSuspensionAppeal(UserSuspensionTestCase):
         self, app: Flask, user_1_admin: User, user_2: User
     ) -> None:
         action = self.create_report_user_action(user_1_admin, user_2)
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         appeal = ReportActionAppeal(
             action_id=action.id,
@@ -4663,7 +4669,7 @@ class TestPostUserSanctionAppeal(CommentMixin, UserSuspensionTestCase):
             app, user_2.email
         )
         text = self.random_string()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             response = client.post(

--- a/fittrackee/tests/users/test_users_api.py
+++ b/fittrackee/tests/users/test_users_api.py
@@ -9,6 +9,7 @@ from flask import Flask
 from sqlalchemy.dialects.postgresql import insert
 
 from fittrackee import db
+from fittrackee.dates import get_readable_duration
 from fittrackee.equipments.models import Equipment
 from fittrackee.reports.models import Report, ReportAction
 from fittrackee.tests.comments.mixins import CommentMixin
@@ -21,7 +22,6 @@ from fittrackee.users.models import (
     UserSportPreferenceEquipment,
 )
 from fittrackee.users.roles import UserRole
-from fittrackee.utils import get_readable_duration
 from fittrackee.visibility_levels import VisibilityLevel
 from fittrackee.workouts.models import Sport, Workout
 

--- a/fittrackee/tests/users/test_users_api.py
+++ b/fittrackee/tests/users/test_users_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from typing import List, Tuple
 from unittest.mock import MagicMock, patch
@@ -444,7 +444,7 @@ class TestGetUsersAsAdmin(ApiTestCaseMixin):
         user_4: User,
     ) -> None:
         user_2.hide_profile_in_users_directory = True
-        user_4.suspended_at = datetime.utcnow()
+        user_4.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
         )
@@ -543,7 +543,7 @@ class TestGetUsersAsAdmin(ApiTestCaseMixin):
     def test_it_gets_users_list_regardless_suspended_status(
         self, app: Flask, user_1_admin: User, user_2: User, user_3: User
     ) -> None:
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
         )
@@ -615,7 +615,7 @@ class TestGetUsersAsAdmin(ApiTestCaseMixin):
         user_3: User,
     ) -> None:
         user_2.hide_profile_in_users_directory = True
-        user_3.suspended_at = datetime.utcnow()
+        user_3.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
         )
@@ -878,9 +878,9 @@ class TestGetUsersPaginationAsAdmin(ApiTestCaseMixin):
     def test_it_gets_users_list_ordered_by_creation_date(
         self, app: Flask, user_2: User, user_3: User, user_1_admin: User
     ) -> None:
-        user_2.created_at = datetime.utcnow() - timedelta(days=1)
-        user_3.created_at = datetime.utcnow() - timedelta(hours=1)
-        user_1_admin.created_at = datetime.utcnow()
+        user_2.created_at = datetime.now(timezone.utc) - timedelta(days=1)
+        user_3.created_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        user_1_admin.created_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
         )
@@ -908,9 +908,9 @@ class TestGetUsersPaginationAsAdmin(ApiTestCaseMixin):
     def test_it_gets_users_list_ordered_by_creation_date_ascending(
         self, app: Flask, user_2: User, user_3: User, user_1_admin: User
     ) -> None:
-        user_2.created_at = datetime.utcnow() - timedelta(days=1)
-        user_3.created_at = datetime.utcnow() - timedelta(hours=1)
-        user_1_admin.created_at = datetime.utcnow()
+        user_2.created_at = datetime.now(timezone.utc) - timedelta(days=1)
+        user_3.created_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        user_1_admin.created_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
         )
@@ -938,9 +938,9 @@ class TestGetUsersPaginationAsAdmin(ApiTestCaseMixin):
     def test_it_gets_users_list_ordered_by_creation_date_descending(
         self, app: Flask, user_2: User, user_3: User, user_1_admin: User
     ) -> None:
-        user_2.created_at = datetime.utcnow() - timedelta(days=1)
-        user_3.created_at = datetime.utcnow() - timedelta(hours=1)
-        user_1_admin.created_at = datetime.utcnow()
+        user_2.created_at = datetime.now(timezone.utc) - timedelta(days=1)
+        user_3.created_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        user_1_admin.created_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
         )
@@ -1222,8 +1222,8 @@ class TestGetUsersPaginationAsAdmin(ApiTestCaseMixin):
         user_3: User,
     ) -> None:
         # default order is ascending
-        user_2.suspended_at = datetime.utcnow() - timedelta(days=2)
-        user_3.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc) - timedelta(days=2)
+        user_3.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
         )
@@ -1258,8 +1258,8 @@ class TestGetUsersPaginationAsAdmin(ApiTestCaseMixin):
         user_2: User,
         user_3: User,
     ) -> None:
-        user_2.suspended_at = datetime.utcnow() - timedelta(days=2)
-        user_3.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc) - timedelta(days=2)
+        user_3.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
         )
@@ -1294,8 +1294,8 @@ class TestGetUsersPaginationAsAdmin(ApiTestCaseMixin):
         user_2: User,
         user_3: User,
     ) -> None:
-        user_2.suspended_at = datetime.utcnow() - timedelta(days=2)
-        user_3.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc) - timedelta(days=2)
+        user_3.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
         )
@@ -1587,7 +1587,7 @@ class TestGetUsersAsModerator(ApiTestCaseMixin):
         input_params: str,
     ) -> None:
         user_2.hide_profile_in_users_directory = True
-        user_4.suspended_at = datetime.utcnow()
+        user_4.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_moderator.email
         )
@@ -1674,7 +1674,7 @@ class TestGetUsersAsUser(ApiTestCaseMixin):
         input_params: str,
     ) -> None:
         user_2.hide_profile_in_users_directory = True
-        user_4.suspended_at = datetime.utcnow()
+        user_4.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
@@ -3526,7 +3526,7 @@ class TestGetUserLatestWorkouts(ApiTestCaseMixin, ReportMixin, CommentMixin):
         workout_cycling_user_2: Workout,
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -3662,7 +3662,7 @@ class TestGetUserLatestWorkouts(ApiTestCaseMixin, ReportMixin, CommentMixin):
         workout_cycling_user_1: Workout,
         workout_cycling_user_2: Workout,
     ) -> None:
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email

--- a/fittrackee/tests/users/test_users_export_data.py
+++ b/fittrackee/tests/users/test_users_export_data.py
@@ -1,6 +1,6 @@
 import os
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Tuple
 from unittest.mock import Mock, call, patch
 
@@ -684,7 +684,7 @@ class UserDataExportTestCase:
     ) -> UserDataExport:
         user_data_export = UserDataExport(
             user_id=user.id,
-            created_at=datetime.utcnow() - timedelta(days=days),
+            created_at=datetime.now(timezone.utc) - timedelta(days=days),
         )
         db.session.add(user_data_export)
         user_data_export.completed = completed

--- a/fittrackee/tests/users/test_users_follow_api.py
+++ b/fittrackee/tests/users/test_users_follow_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from flask import Flask
@@ -63,7 +63,9 @@ class TestFollow(ApiTestCaseMixin):
         follow_request_from_user_1_to_user_2: FollowRequest,
     ) -> None:
         follow_request_from_user_1_to_user_2.is_approved = False
-        follow_request_from_user_1_to_user_2.updated_at = datetime.utcnow()
+        follow_request_from_user_1_to_user_2.updated_at = datetime.now(
+            timezone.utc
+        )
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )

--- a/fittrackee/tests/users/test_users_follow_request_api.py
+++ b/fittrackee/tests/users/test_users_follow_request_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -65,7 +65,9 @@ class TestGetFollowRequest(ApiTestCaseMixin):
         follow_request_from_user_3_to_user_1: FollowRequest,
         follow_request_from_user_3_to_user_2: FollowRequest,
     ) -> None:
-        follow_request_from_user_2_to_user_1.updated_at = datetime.utcnow()
+        follow_request_from_user_2_to_user_1.updated_at = datetime.now(
+            timezone.utc
+        )
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
@@ -361,7 +363,7 @@ class TestAcceptFollowRequest(FollowRequestTestCase):
         user_2: User,
         follow_request_from_user_2_to_user_1: FollowRequest,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
@@ -406,7 +408,9 @@ class TestAcceptFollowRequest(FollowRequestTestCase):
         user_2: User,
         follow_request_from_user_2_to_user_1: FollowRequest,
     ) -> None:
-        follow_request_from_user_2_to_user_1.updated_at = datetime.utcnow()
+        follow_request_from_user_2_to_user_1.updated_at = datetime.now(
+            timezone.utc
+        )
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
@@ -481,7 +485,7 @@ class TestRejectFollowRequest(FollowRequestTestCase):
         user_2: User,
         follow_request_from_user_2_to_user_1: FollowRequest,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
@@ -526,7 +530,9 @@ class TestRejectFollowRequest(FollowRequestTestCase):
         user_2: User,
         follow_request_from_user_2_to_user_1: FollowRequest,
     ) -> None:
-        follow_request_from_user_2_to_user_1.updated_at = datetime.utcnow()
+        follow_request_from_user_2_to_user_1.updated_at = datetime.now(
+            timezone.utc
+        )
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )

--- a/fittrackee/tests/users/test_users_followers_api.py
+++ b/fittrackee/tests/users/test_users_followers_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 from unittest.mock import patch
 
@@ -20,7 +20,7 @@ class FollowersAsUserTestCase(ApiTestCaseMixin):
     ) -> None:
         for follows_request in follows_requests:
             follows_request.is_approved = True
-            follows_request.updated_at = datetime.utcnow()
+            follows_request.updated_at = datetime.now(timezone.utc)
 
 
 class TestFollowersAsUnauthenticatedUser(ApiTestCaseMixin):
@@ -44,7 +44,7 @@ class TestFollowersAsSuspendedUser(ApiTestCaseMixin):
         user_1: User,
         user_2: User,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
@@ -137,7 +137,7 @@ class TestFollowersAsUser(FollowersAsUserTestCase):
         follow_request_from_user_2_to_user_1: FollowRequest,
     ) -> None:
         self.approves_follow_requests([follow_request_from_user_2_to_user_1])
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
 
         client, auth_token = self.get_test_client_and_auth_token(
@@ -266,7 +266,7 @@ class TestFollowersAsAdmin(FollowersAsUserTestCase):
                 follow_request_from_user_3_to_user_2,
             ]
         )
-        user_3.suspended_at = datetime.utcnow()
+        user_3.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
@@ -401,7 +401,7 @@ class TestFollowingAsSuspendedUser(ApiTestCaseMixin):
         user_1: User,
         user_2: User,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )
@@ -501,7 +501,7 @@ class TestFollowingAsUser(FollowersAsUserTestCase):
                 follow_request_from_user_3_to_user_1,
             ]
         )
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -630,7 +630,7 @@ class TestFollowingAsAdmin(FollowersAsUserTestCase):
                 follow_request_from_user_3_to_user_1,
             ]
         )
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email

--- a/fittrackee/tests/users/test_users_notifications_api.py
+++ b/fittrackee/tests/users/test_users_notifications_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -675,7 +675,7 @@ class TestUserNotifications(CommentMixin, ReportMixin, ApiTestCaseMixin):
         user_2: User,
         follow_request_from_user_2_to_user_1: FollowRequest,
     ) -> None:
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -707,7 +707,7 @@ class TestUserNotifications(CommentMixin, ReportMixin, ApiTestCaseMixin):
         follow_request_from_user_1_to_user_2: FollowRequest,
     ) -> None:
         user_2.approves_follow_request_from(user_1)
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -744,7 +744,7 @@ class TestUserNotifications(CommentMixin, ReportMixin, ApiTestCaseMixin):
             user_id=user_2.id, workout_id=workout_cycling_user_1.id
         )
         db.session.add(like)
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -784,7 +784,7 @@ class TestUserNotifications(CommentMixin, ReportMixin, ApiTestCaseMixin):
         )
         like = CommentLike(user_id=user_2.id, comment_id=comment.id)
         db.session.add(like)
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -822,7 +822,7 @@ class TestUserNotifications(CommentMixin, ReportMixin, ApiTestCaseMixin):
             workout_cycling_user_1,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -862,7 +862,7 @@ class TestUserNotifications(CommentMixin, ReportMixin, ApiTestCaseMixin):
             text_visibility=VisibilityLevel.PUBLIC,
             with_mentions=True,
         )
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -971,7 +971,7 @@ class TestUserNotifications(CommentMixin, ReportMixin, ApiTestCaseMixin):
         user_3: User,
     ) -> None:
         self.create_user_report(user_2, user_3)
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1_admin.email
@@ -1419,7 +1419,7 @@ class TestUserNotificationsStatus(CommentMixin, ReportMixin, ApiTestCaseMixin):
         )
         db.session.add(like)
         db.session.flush()
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
 
         client, auth_token = self.get_test_client_and_auth_token(

--- a/fittrackee/tests/users/test_users_notifications_model.py
+++ b/fittrackee/tests/users/test_users_notifications_model.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pytest
@@ -75,7 +75,7 @@ class TestNotification:
             Notification(
                 from_user_id=user_1.id,
                 to_user_id=user_2.id,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
                 event_type=random_string(),
                 event_object_id=random_int(),
             )
@@ -203,7 +203,7 @@ class TestNotificationForFollowRequest:
     ) -> None:
         user_2.update_preferences({"follow_request": False})
         user_1.send_follow_request_to(user_2)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             user_2.approves_follow_request_from(user_1)
@@ -221,7 +221,7 @@ class TestNotificationForFollowRequest:
         self, app: Flask, user_1: User, user_2: User
     ) -> None:
         user_1.send_follow_request_to(user_2)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             user_2.approves_follow_request_from(user_1)

--- a/fittrackee/tests/users/test_users_service.py
+++ b/fittrackee/tests/users/test_users_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from flask import Flask
@@ -559,7 +559,7 @@ class TestUserManagerServiceUserUpdate(ReportMixin):
         self, app: Flask, user_1: User, user_2_admin: User
     ) -> None:
         report = self.generate_user_report(user_2_admin, user_1)
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         user_manager_service = UserManagerService(
             username=user_1.username,
             moderator_id=user_2_admin.id,
@@ -578,7 +578,7 @@ class TestUserManagerServiceUserUpdate(ReportMixin):
         user_manager_service = UserManagerService(
             username=user_1.username, moderator_id=user_2_admin.id
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             _, user_updated, _, _ = user_manager_service.update(
@@ -597,7 +597,7 @@ class TestUserManagerServiceUserUpdate(ReportMixin):
             username=user_1_admin.username,
             moderator_id=user_2_admin.id,
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             _, user_updated, _, _ = user_manager_service.update(
@@ -613,7 +613,7 @@ class TestUserManagerServiceUserUpdate(ReportMixin):
         self, app: Flask, user_1: User, user_2_admin: User
     ) -> None:
         report = self.generate_user_report(user_2_admin, user_1)
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         user_manager_service = UserManagerService(
             username=user_1.username,
             moderator_id=user_2_admin.id,
@@ -631,7 +631,7 @@ class TestUserManagerServiceUserUpdate(ReportMixin):
         self, app: Flask, user_1: User, user_2_admin: User
     ) -> None:
         report = self.generate_user_report(user_2_admin, user_1)
-        suspended_at = datetime.utcnow()
+        suspended_at = datetime.now(timezone.utc)
         user_1.suspended_at = suspended_at
         user_manager_service = UserManagerService(
             username=user_1.username,
@@ -664,9 +664,9 @@ class TestUserManagerServiceUserUpdate(ReportMixin):
             moderator_id=user_1_admin.id, username=user_2.username
         )
         if input_suspended is False:
-            user_2.suspended_at = datetime.utcnow()
+            user_2.suspended_at = datetime.now(timezone.utc)
             db.session.commit()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             user_manager_service.update(

--- a/fittrackee/tests/users/test_users_utils.py
+++ b/fittrackee/tests/users/test_users_utils.py
@@ -1,6 +1,6 @@
 import time
 from calendar import timegm
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 from unittest.mock import patch
 
@@ -214,7 +214,7 @@ class TestGetUserToken:
         self, app: Flask, input_password_reset: bool
     ) -> None:
         user_id = 1
-        iat = datetime.utcnow()
+        iat = datetime.now(timezone.utc)
         with travel(iat, tick=False):
             token = get_user_token(
                 user_id=user_id, password_reset=input_password_reset
@@ -227,7 +227,7 @@ class TestGetUserToken:
         self, app: Flask
     ) -> None:
         user_id = 1
-        iat = datetime.utcnow()
+        iat = datetime.now(timezone.utc)
         expiration = timedelta(
             days=app.config['TOKEN_EXPIRATION_DAYS'],
             seconds=app.config['TOKEN_EXPIRATION_SECONDS'],
@@ -244,7 +244,7 @@ class TestGetUserToken:
         self, app: Flask
     ) -> None:
         user_id = 1
-        iat = datetime.utcnow()
+        iat = datetime.now(timezone.utc)
         expiration = timedelta(
             days=0.0,
             seconds=app.config['PASSWORD_TOKEN_EXPIRATION_SECONDS'],
@@ -284,7 +284,7 @@ class TestDecodeUserToken:
     def test_it_raises_error_when_secret_key_is_invalid(
         self, app: Flask
     ) -> None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         token = jwt.encode(
             {
                 'exp': now + timedelta(minutes=1),
@@ -309,7 +309,7 @@ class TestDecodeUserToken:
             serialization.PrivateFormat.PKCS8,
             serialization.NoEncryption(),
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         token = jwt.encode(
             {
                 'exp': now + timedelta(minutes=1),
@@ -323,7 +323,7 @@ class TestDecodeUserToken:
             decode_user_token(token)
 
     def test_it_raises_error_when_token_is_expired(self, app: Flask) -> None:
-        now = datetime.utcnow() - timedelta(minutes=10)
+        now = datetime.now(timezone.utc) - timedelta(minutes=10)
         token = self.generate_token(user_id=1, now=now)
         with pytest.raises(
             jwt.exceptions.ExpiredSignatureError, match='Signature has expired'
@@ -333,7 +333,7 @@ class TestDecodeUserToken:
     def test_it_returns_user_id(self, app: Flask) -> None:
         expected_user_id = 1
         token = self.generate_token(
-            user_id=expected_user_id, now=datetime.utcnow()
+            user_id=expected_user_id, now=datetime.now(timezone.utc)
         )
 
         user_id = decode_user_token(token)

--- a/fittrackee/tests/utils.py
+++ b/fittrackee/tests/utils.py
@@ -1,6 +1,6 @@
 import random
 import string
-from datetime import datetime
+from datetime import datetime, timezone
 from json import dumps, loads
 from typing import Dict, Optional, Union
 from uuid import uuid4
@@ -39,7 +39,7 @@ def get_date_string(
     date_format: str,
     date: Optional[datetime] = None,
 ) -> str:
-    date = date if date else datetime.utcnow()
+    date = date if date else datetime.now(timezone.utc)
     return date.strftime(date_format)
 
 

--- a/fittrackee/tests/workouts/test_stats_api.py
+++ b/fittrackee/tests/workouts/test_stats_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List
 
 import pytest
@@ -17,13 +17,13 @@ from ..utils import OAUTH_SCOPES
 class TestGetStatsByTime(ApiTestCaseMixin):
     @staticmethod
     def create_workouts(
-        user: User, sport: Sport, workout_dates: List[str]
+        user: User, sport: Sport, workout_dates: List[datetime]
     ) -> None:
         for workout_date in workout_dates:
             workout = Workout(
                 user_id=user.id,
                 sport_id=sport.id,
-                workout_date=datetime.strptime(workout_date, '%d/%m/%Y %H:%M'),
+                workout_date=workout_date,
                 distance=5,
                 duration=timedelta(seconds=1024),
             )
@@ -234,7 +234,7 @@ class TestGetStatsByTime(ApiTestCaseMixin):
             [
                 # workout_date: '31 Dec 2024 23:00:00 GMT'
                 # '1 Dec 2025 00:00:00' in 'Europe/Paris' timezone
-                '31/12/2024 23:00'
+                datetime(2024, 12, 31, 23, tzinfo=timezone.utc)
             ],
         )
         client, auth_token = self.get_test_client_and_auth_token(
@@ -273,10 +273,10 @@ class TestGetStatsByTime(ApiTestCaseMixin):
             [
                 # workout_date: '01 Jan 2025 04:00:00 GMT'
                 # '31 Dec 2024 23:00:00' in 'America/New_York' timezone
-                '01/01/2025 04:00',
+                datetime(2025, 1, 1, 4, tzinfo=timezone.utc),
                 # workout_date: '01 Jan 2025 05:00:00 GMT'
                 # '01 Jan 2025 00:00:00' in 'America/New_York' timezone
-                '01/01/2025 05:00',
+                datetime(2025, 1, 1, 5, tzinfo=timezone.utc),
             ],
         )
         client, auth_token = self.get_test_client_and_auth_token(

--- a/fittrackee/tests/workouts/test_timeline_api.py
+++ b/fittrackee/tests/workouts/test_timeline_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 import pytest
@@ -159,7 +159,7 @@ class TestGetUserTimelineForAuthUserWorkouts(GetUserTimelineTestCase):
         sport_1_cycling: Sport,
         workout_cycling_user_1: Workout,
     ) -> None:
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -312,7 +312,7 @@ class TestGetUserTimelineForFollowedUserWorkouts(GetUserTimelineTestCase):
     ) -> None:
         user_2.approves_follow_request_from(user_1)
         workout_cycling_user_2.workout_visibility = input_workout_visibility
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         user_1.blocks_user(user_2)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(

--- a/fittrackee/tests/workouts/test_utils/test_weather_service.py
+++ b/fittrackee/tests/workouts/test_utils/test_weather_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional
 from unittest.mock import Mock, patch, sentinel
 
@@ -9,6 +9,7 @@ from gpxpy.gpx import GPXTrackPoint
 
 from fittrackee.tests.mixins import BaseTestMixin
 from fittrackee.tests.utils import random_string
+from fittrackee.utils import get_datetime_in_utc
 from fittrackee.workouts.utils.weather.visual_crossing import VisualCrossing
 from fittrackee.workouts.utils.weather.weather_service import WeatherService
 
@@ -56,7 +57,7 @@ class WeatherTestCase(BaseTestMixin):
 
 class TestVisualCrossingGetTimestamp(WeatherTestCase):
     def test_it_returns_expected_timestamp_as_integer(self) -> None:
-        time = datetime.utcnow()
+        time = datetime.now(timezone.utc)
         visual_crossing = VisualCrossing(api_key=self.api_key)
 
         timestamp = visual_crossing._get_timestamp(time)
@@ -75,16 +76,15 @@ class TestVisualCrossingGetTimestamp(WeatherTestCase):
     def test_it_returns_rounded_time(
         self, input_datetime: str, expected_datetime: str
     ) -> None:
-        time = datetime.strptime(input_datetime, '%Y-%m-%dT%H:%M:%S')
+        date_format = '%Y-%m-%dT%H:%M:%S'
+        time = get_datetime_in_utc(input_datetime, date_format)
         visual_crossing = VisualCrossing(api_key=self.api_key)
 
         timestamp = visual_crossing._get_timestamp(time)
 
         assert (
             timestamp
-            == datetime.strptime(
-                expected_datetime, '%Y-%m-%dT%H:%M:%S'
-            ).timestamp()
+            == get_datetime_in_utc(expected_datetime, date_format).timestamp()
         )
 
 

--- a/fittrackee/tests/workouts/test_utils/test_weather_service.py
+++ b/fittrackee/tests/workouts/test_utils/test_weather_service.py
@@ -7,9 +7,9 @@ import pytz
 import requests
 from gpxpy.gpx import GPXTrackPoint
 
+from fittrackee.dates import get_datetime_in_utc
 from fittrackee.tests.mixins import BaseTestMixin
 from fittrackee.tests.utils import random_string
-from fittrackee.utils import get_datetime_in_utc
 from fittrackee.workouts.utils.weather.visual_crossing import VisualCrossing
 from fittrackee.workouts.utils.weather.weather_service import WeatherService
 

--- a/fittrackee/tests/workouts/test_utils/test_workouts.py
+++ b/fittrackee/tests/workouts/test_utils/test_workouts.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from statistics import mean
 from typing import List, Optional, Union
 
@@ -60,34 +60,48 @@ class TestWorkoutAverageSpeed:
 
 class TestWorkoutGetWorkoutDatetime:
     @pytest.mark.parametrize('input_workout_date', input_workout_dates)
-    def test_it_returns_naive_datetime(
+    def test_it_returns_datetime_in_utc(
         self, input_workout_date: Union[datetime, str]
     ) -> None:
-        naive_workout_date, _ = get_workout_datetime(
+        workout_date, _ = get_workout_datetime(
             workout_date=input_workout_date, user_timezone='Europe/Paris'
         )
 
-        assert naive_workout_date == datetime(
-            year=2022, month=6, day=11, hour=10, minute=23, second=00
+        assert workout_date == datetime(
+            year=2022,
+            month=6,
+            day=11,
+            hour=10,
+            minute=23,
+            second=00,
+            tzinfo=timezone.utc,
         )
 
-    def test_it_return_naive_datetime_when_no_user_timezone(self) -> None:
-        naive_workout_date, _ = get_workout_datetime(
+    def test_it_return_datetime_in_utc_when_no_user_timezone(self) -> None:
+        workout_date, _ = get_workout_datetime(
             workout_date='2022-06-11 12:23:00', user_timezone=None
         )
 
-        assert naive_workout_date == datetime(
-            year=2022, month=6, day=11, hour=12, minute=23, second=00
+        assert workout_date == datetime(
+            year=2022,
+            month=6,
+            day=11,
+            hour=12,
+            minute=23,
+            second=00,
+            tzinfo=timezone.utc,
         )
 
     @pytest.mark.parametrize('input_workout_date', input_workout_dates)
     def test_it_returns_datetime_with_user_timezone(
         self, input_workout_date: Union[datetime, str]
     ) -> None:
-        timezone = 'Europe/Paris'
+        user_timezone = 'Europe/Paris'
 
         _, workout_date_with_tz = get_workout_datetime(
-            input_workout_date, user_timezone=timezone, with_timezone=True
+            input_workout_date,
+            user_timezone=user_timezone,
+            with_user_timezone=True,
         )
 
         assert workout_date_with_tz == datetime(
@@ -98,7 +112,7 @@ class TestWorkoutGetWorkoutDatetime:
             minute=23,
             second=00,
             tzinfo=pytz.utc,
-        ).astimezone(pytz.timezone(timezone))
+        ).astimezone(pytz.timezone(user_timezone))
 
     def test_it_does_not_return_datetime_with_user_timezone_when_no_user_tz(
         self,
@@ -106,7 +120,7 @@ class TestWorkoutGetWorkoutDatetime:
         _, workout_date_with_tz = get_workout_datetime(
             workout_date='2022-06-11 12:23:00',
             user_timezone=None,
-            with_timezone=True,
+            with_user_timezone=True,
         )
 
         assert workout_date_with_tz is None
@@ -117,7 +131,7 @@ class TestWorkoutGetWorkoutDatetime:
         _, workout_date_with_tz = get_workout_datetime(
             workout_date='2022-06-11 12:23:00',
             user_timezone='Europe/Paris',
-            with_timezone=False,
+            with_user_timezone=False,
         )
 
         assert workout_date_with_tz is None

--- a/fittrackee/tests/workouts/test_workout_likes_model.py
+++ b/fittrackee/tests/workouts/test_workout_likes_model.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import Flask
 from time_machine import travel
@@ -17,7 +17,7 @@ class TestWorkoutLikeModel:
         user_2: User,
         workout_cycling_user_1: Workout,
     ) -> None:
-        created_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
 
         like = WorkoutLike(
             user_id=user_2.id,
@@ -37,7 +37,7 @@ class TestWorkoutLikeModel:
         user_2: User,
         workout_cycling_user_1: Workout,
     ) -> None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         with travel(now, tick=False):
             like = WorkoutLike(
                 user_id=user_2.id,

--- a/fittrackee/tests/workouts/test_workouts_api_0_get_workout.py
+++ b/fittrackee/tests/workouts/test_workouts_api_0_get_workout.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 from unittest.mock import mock_open, patch
 
@@ -59,7 +59,7 @@ class TestGetWorkoutAsWorkoutOwner(GetWorkoutTestCase):
         sport_1_cycling: Sport,
         workout_cycling_user_1: Workout,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -103,7 +103,7 @@ class TestGetWorkoutAsWorkoutOwner(GetWorkoutTestCase):
         sport_1_cycling: Sport,
         workout_cycling_user_1: Workout,
     ) -> None:
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -160,7 +160,7 @@ class TestGetWorkoutAsFollower(CommentMixin, GetWorkoutTestCase):
         user_2.approves_follow_request_from(user_1)
         user_2.approves_follow_request_from(user_3)
         workout_cycling_user_2.workout_visibility = VisibilityLevel.FOLLOWERS
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         self.create_comment(
             user_3,
             workout_cycling_user_2,
@@ -190,7 +190,7 @@ class TestGetWorkoutAsFollower(CommentMixin, GetWorkoutTestCase):
     ) -> None:
         user_2.approves_follow_request_from(user_1)
         workout_cycling_user_2.workout_visibility = VisibilityLevel.FOLLOWERS
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         self.create_comment(
             user_1,
             workout_cycling_user_2,
@@ -270,7 +270,7 @@ class TestGetWorkoutAsFollower(CommentMixin, GetWorkoutTestCase):
     ) -> None:
         user_2.approves_follow_request_from(user_1)
         workout_cycling_user_2.workout_visibility = VisibilityLevel.FOLLOWERS
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -311,7 +311,7 @@ class TestGetWorkoutAsUser(CommentMixin, GetWorkoutTestCase):
         workout_cycling_user_2: Workout,
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         self.create_comment(
             user_3,
             workout_cycling_user_2,
@@ -339,7 +339,7 @@ class TestGetWorkoutAsUser(CommentMixin, GetWorkoutTestCase):
         workout_cycling_user_2: Workout,
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         self.create_comment(
             user_1,
             workout_cycling_user_2,
@@ -462,7 +462,7 @@ class TestGetWorkoutAsUser(CommentMixin, GetWorkoutTestCase):
         workout_cycling_user_2: Workout,
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -499,7 +499,7 @@ class TestGetWorkoutAsUnauthenticatedUser(GetWorkoutTestCase):
         workout_cycling_user_1: Workout,
     ) -> None:
         workout_cycling_user_1.workout_visibility = VisibilityLevel.PUBLIC
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client = app.test_client()
 
@@ -609,7 +609,7 @@ class TestGetWorkoutGpxAsWorkoutOwner(GetWorkoutGpxTestCase):
     ) -> None:
         gpx_content = self.random_string()
         workout_cycling_user_1.gpx = 'file.gpx'
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -751,7 +751,7 @@ class TestGetWorkoutGpxAsFollower(
             followed=user_2,
         )
         gpx_content = self.random_string()
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -873,7 +873,7 @@ class TestGetWorkoutGpxAsUser(
             workout_cycling_user_2, map_visibility=VisibilityLevel.PUBLIC
         )
         gpx_content = self.random_string()
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -1060,7 +1060,7 @@ class TestGetWorkoutChartDataAsWorkoutOwner(GetWorkoutChartDataTestCase):
         workout_cycling_user_1: Workout,
     ) -> None:
         workout_cycling_user_1.gpx = 'file.gpx'
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -1172,7 +1172,7 @@ class TestGetWorkoutChartDataAsFollower(
             follower=user_1,
             followed=user_2,
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -1296,7 +1296,7 @@ class TestGetWorkoutChartDataAsUser(
             app, user_1.email
         )
         workout_cycling_user_2.gpx = 'file.gpx'
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
 
         response = client.get(
@@ -1486,7 +1486,7 @@ class TestGetWorkoutSegmentGpxAsWorkoutOwner(GetWorkoutSegmentGpxTestCase):
         gpx_file_with_segments: str,
     ) -> None:
         workout_cycling_user_1.gpx = 'file.gpx'
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -1606,7 +1606,7 @@ class TestGetWorkoutSegmentGpxAsFollower(
             follower=user_2,
             followed=user_1,
         )
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_2.email
@@ -1736,7 +1736,7 @@ class TestGetWorkoutSegmentGpxAsUser(
         self.init_test_data_for_public_workout(
             workout_cycling_user_1, map_visibility=VisibilityLevel.PUBLIC
         )
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_2.email
@@ -1928,7 +1928,7 @@ class TestGetWorkoutSegmentChartDataAsWorkoutOwner(
         workout_cycling_user_1: Workout,
         workout_cycling_user_1_segment: WorkoutSegment,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -2048,7 +2048,7 @@ class TestGetWorkoutSegmentChartDataAsFollower(
             follower=user_2,
             followed=user_1,
         )
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_2.email
@@ -2186,7 +2186,7 @@ class TestGetWorkoutSegmentChartDataAsUser(
             map_visibility=VisibilityLevel.PRIVATE,
         )
         workout_cycling_user_1.gpx = 'file.gpx'
-        user_2.suspended_at = datetime.utcnow()
+        user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_2.email
@@ -2456,7 +2456,7 @@ class TestDownloadWorkoutGpxAsWorkoutOwner(DownloadWorkoutGpxTestCase):
         workout_cycling_user_1: Workout,
     ) -> None:
         workout_cycling_user_1.gpx = 'file.gpx'
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email

--- a/fittrackee/tests/workouts/test_workouts_api_0_get_workouts.py
+++ b/fittrackee/tests/workouts/test_workouts_api_0_get_workouts.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List
 from unittest.mock import patch
 
@@ -168,7 +168,7 @@ class TestGetWorkouts(WorkoutApiTestCaseMixin):
         workout_cycling_user_1: Workout,
         workout_running_user_1: Workout,
     ) -> None:
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email

--- a/fittrackee/tests/workouts/test_workouts_api_1_post.py
+++ b/fittrackee/tests/workouts/test_workouts_api_1_post.py
@@ -1,6 +1,6 @@
 import json
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from typing import Any, Dict, Optional
 from unittest.mock import Mock, patch
@@ -3848,8 +3848,8 @@ class TestPostAndGetWorkoutUsingTimezones(WorkoutApiTestCaseMixin):
             headers=dict(Authorization=f'Bearer {auth_token}'),
         )
 
-        workout_cycling_user_1.workout_date = datetime.strptime(
-            '31/01/2018 21:59:59', '%d/%m/%Y %H:%M:%S'
+        workout_cycling_user_1.workout_date = datetime(
+            2018, 1, 31, 21, 59, 59, tzinfo=timezone.utc
         )
         workout_cycling_user_1.title = 'Test'
 
@@ -3979,7 +3979,7 @@ class TestPostWorkoutSuspensionAppeal(
         sport_1_cycling: Sport,
         workout_cycling_user_1: Workout,
     ) -> None:
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -4006,7 +4006,7 @@ class TestPostWorkoutSuspensionAppeal(
         workout_cycling_user_1: Workout,
         input_data: Dict,
     ) -> None:
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         self.create_report_workout_action(
             user_2_admin, user_1, workout_cycling_user_1
         )
@@ -4032,7 +4032,7 @@ class TestPostWorkoutSuspensionAppeal(
         sport_1_cycling: Sport,
         workout_cycling_user_1: Workout,
     ) -> None:
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         action = self.create_report_workout_action(
             user_2_admin, user_1, workout_cycling_user_1
         )
@@ -4041,7 +4041,7 @@ class TestPostWorkoutSuspensionAppeal(
             app, user_1.email
         )
         text = self.random_string()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         with travel(now, tick=False):
             response = client.post(
@@ -4070,7 +4070,7 @@ class TestPostWorkoutSuspensionAppeal(
         sport_1_cycling: Sport,
         workout_cycling_user_1: Workout,
     ) -> None:
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         action = self.create_report_workout_action(
             user_2_admin, user_1, workout_cycling_user_1
         )

--- a/fittrackee/tests/workouts/test_workouts_api_2_patch.py
+++ b/fittrackee/tests/workouts/test_workouts_api_2_patch.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict
 from uuid import uuid4
 
@@ -424,7 +424,7 @@ class TestEditWorkoutWithGpx(WorkoutApiTestCaseMixin):
             app, gpx_file, workout_visibility=VisibilityLevel.PRIVATE
         )
         client = app.test_client()
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
 
         response = client.patch(
@@ -1149,7 +1149,7 @@ class TestEditWorkoutWithoutGpx(WorkoutApiTestCaseMixin):
         sport_1_cycling: Sport,
         workout_cycling_user_1: Workout,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email

--- a/fittrackee/tests/workouts/test_workouts_api_3_delete.py
+++ b/fittrackee/tests/workouts/test_workouts_api_3_delete.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from flask import Flask
@@ -221,7 +221,7 @@ class TestDeleteWorkoutWithGpx(CommentMixin, WorkoutApiTestCaseMixin):
         auth_token, workout_short_id = post_a_workout(
             app, gpx_file, workout_visibility=VisibilityLevel.PRIVATE
         )
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client = app.test_client()
 
@@ -541,7 +541,7 @@ class TestDeleteWorkoutWithoutGpx(CommentMixin, WorkoutApiTestCaseMixin):
         sport_1_cycling: Sport,
         workout_cycling_user_1: Workout,
     ) -> None:
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email

--- a/fittrackee/tests/workouts/test_workouts_likes_api.py
+++ b/fittrackee/tests/workouts/test_workouts_likes_api.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -44,7 +44,7 @@ class TestWorkoutLikePost(ApiTestCaseMixin, BaseTestMixin):
     ) -> None:
         user_2.approves_follow_request_from(user_1)
         workout_cycling_user_2.workout_visibility = VisibilityLevel.FOLLOWERS
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -66,7 +66,7 @@ class TestWorkoutLikePost(ApiTestCaseMixin, BaseTestMixin):
         workout_cycling_user_2: Workout,
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -289,7 +289,7 @@ class TestWorkoutUndoLikePost(ApiTestCaseMixin, BaseTestMixin):
         )
         db.session.add(like)
         db.session.flush()
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
 
         response = client.post(
@@ -366,7 +366,7 @@ class TestWorkoutUndoLikePost(ApiTestCaseMixin, BaseTestMixin):
         workout_cycling_user_2: Workout,
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.PUBLIC
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -507,7 +507,7 @@ class TestWorkoutLikesGet(ApiTestCaseMixin, BaseTestMixin):
     ) -> None:
         user_2.approves_follow_request_from(user_1)
         workout_cycling_user_2.workout_visibility = VisibilityLevel.FOLLOWERS
-        user_1.suspended_at = datetime.utcnow()
+        user_1.suspended_at = datetime.now(timezone.utc)
         db.session.commit()
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
@@ -587,7 +587,7 @@ class TestWorkoutLikesGet(ApiTestCaseMixin, BaseTestMixin):
         workout_cycling_user_2: Workout,
     ) -> None:
         workout_cycling_user_2.workout_visibility = VisibilityLevel.FOLLOWERS
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         client, auth_token = self.get_test_client_and_auth_token(
             app, user_1.email
         )

--- a/fittrackee/tests/workouts/test_workouts_model.py
+++ b/fittrackee/tests/workouts/test_workouts_model.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
 import pytest
@@ -59,9 +59,9 @@ class TestWorkoutModelForOwner(WorkoutModelTestCase):
         workout_cycling_user_1.title = 'Test'
         db.session.commit()
         assert (
-            f'<Workout \'{sport_1_cycling.label}\' - 2018-01-01 00:00:00>'
-            == str(workout_cycling_user_1)
-        )
+            f'<Workout \'{sport_1_cycling.label}\' '
+            '- 2018-01-01 00:00:00+00:00>'
+        ) == str(workout_cycling_user_1)
 
     def test_short_id_returns_encoded_workout_uuid(
         self,
@@ -95,7 +95,7 @@ class TestWorkoutModelForOwner(WorkoutModelTestCase):
         expected_report_action = self.create_report_workout_action(
             user_1_admin, user_2, workout_cycling_user_2
         )
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
 
         assert (
             workout_cycling_user_2.suspension_action == expected_report_action
@@ -368,7 +368,7 @@ class TestWorkoutModelForOwner(WorkoutModelTestCase):
         input_workout_visibility: VisibilityLevel,
     ) -> None:
         workout_cycling_user_1.workout_visibility = input_workout_visibility
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         expected_report_action = self.create_report_workout_action(
             user_2_admin, user_1, workout_cycling_user_1
         )
@@ -544,7 +544,7 @@ class TestWorkoutModelForOwner(WorkoutModelTestCase):
         user_2_admin: User,
         workout_cycling_user_1: Workout,
     ) -> None:
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         self.create_report_workout_action(
             user_2_admin, user_1, workout_cycling_user_1
         )
@@ -1183,7 +1183,7 @@ class TestWorkoutModelAsFollower(CommentMixin, WorkoutModelTestCase):
             workout_cycling_user_1,
             text_visibility=VisibilityLevel.FOLLOWERS,
         )
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
 
         with pytest.raises(WorkoutForbiddenException):
             workout_cycling_user_1.serialize(
@@ -1209,7 +1209,7 @@ class TestWorkoutModelAsFollower(CommentMixin, WorkoutModelTestCase):
         self.create_report_workout_action(
             user_2_admin, user_1, workout_cycling_user_1
         )
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
 
         serialized_workout = workout_cycling_user_1.serialize(
             user=user_3, light=False
@@ -1607,7 +1607,7 @@ class TestWorkoutModelAsUser(CommentMixin, WorkoutModelTestCase):
         input_for_report: bool,
     ) -> None:
         workout_cycling_user_1.workout_visibility = VisibilityLevel.PUBLIC
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
         self.create_comment(
             user_3,
             workout_cycling_user_1,
@@ -1637,7 +1637,7 @@ class TestWorkoutModelAsUser(CommentMixin, WorkoutModelTestCase):
         self.create_report_workout_action(
             user_2_admin, user_1, workout_cycling_user_1
         )
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
 
         serialized_workout = workout_cycling_user_1.serialize(
             user=user_3, light=False
@@ -2045,7 +2045,7 @@ class TestWorkoutModelAsUnauthenticatedUser(
             workout_cycling_user_1,
             text_visibility=VisibilityLevel.PUBLIC,
         )
-        workout_cycling_user_1.suspended_at = datetime.utcnow()
+        workout_cycling_user_1.suspended_at = datetime.now(timezone.utc)
 
         with pytest.raises(WorkoutForbiddenException):
             workout_cycling_user_1.serialize(for_report=input_for_report)
@@ -2311,7 +2311,7 @@ class TestWorkoutModelAsModerator(WorkoutModelTestCase):
         input_workout_visibility: VisibilityLevel,
     ) -> None:
         workout_cycling_user_2.workout_visibility = input_workout_visibility
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
 
         with pytest.raises(WorkoutForbiddenException):
             workout_cycling_user_2.serialize(
@@ -2336,7 +2336,7 @@ class TestWorkoutModelAsModerator(WorkoutModelTestCase):
         input_workout_visibility: VisibilityLevel,
     ) -> None:
         workout_cycling_user_2.workout_visibility = input_workout_visibility
-        workout_cycling_user_2.suspended_at = datetime.utcnow()
+        workout_cycling_user_2.suspended_at = datetime.now(timezone.utc)
         expected_report_action = self.create_report_workout_action(
             user_1_moderator, user_2, workout_cycling_user_2
         )

--- a/fittrackee/users/auth.py
+++ b/fittrackee/users/auth.py
@@ -18,6 +18,7 @@ from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.utils import secure_filename
 
 from fittrackee import appLog, db
+from fittrackee.dates import get_datetime_in_utc, get_readable_duration
 from fittrackee.emails.tasks import (
     account_confirmation_email,
     email_updated_to_current_address,
@@ -32,6 +33,7 @@ from fittrackee.equipments.exceptions import (
 from fittrackee.equipments.utils import handle_equipments
 from fittrackee.files import get_absolute_file_path
 from fittrackee.oauth2.server import require_auth
+from fittrackee.reports.models import ReportAction, ReportActionAppeal
 from fittrackee.responses import (
     DataNotFoundErrorResponse,
     EquipmentInvalidPayloadErrorResponse,
@@ -47,8 +49,6 @@ from fittrackee.responses import (
 from fittrackee.users.users_service import UserManagerService
 from fittrackee.utils import (
     decode_short_id,
-    get_datetime_in_utc,
-    get_readable_duration,
 )
 from fittrackee.visibility_levels import (
     VisibilityLevel,
@@ -56,7 +56,6 @@ from fittrackee.visibility_levels import (
 )
 from fittrackee.workouts.models import Sport
 
-from ..reports.models import ReportAction, ReportActionAppeal
 from .exceptions import UserControlsException, UserCreationException
 from .models import (
     BlacklistedToken,

--- a/fittrackee/users/export_data.py
+++ b/fittrackee/users/export_data.py
@@ -1,7 +1,7 @@
 import json
 import os
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple, Union
 from zipfile import ZipFile
 
@@ -176,7 +176,7 @@ def export_user_data(export_request_id: int) -> None:
 
 def clean_user_data_export(days: int) -> Dict:
     counts = {"deleted_requests": 0, "deleted_archives": 0, "freed_space": 0}
-    limit = datetime.utcnow() - timedelta(days=days)
+    limit = datetime.now(timezone.utc) - timedelta(days=days)
     export_requests = UserDataExport.query.filter(
         UserDataExport.created_at < limit,
         UserDataExport.completed == True,  # noqa

--- a/fittrackee/users/models.py
+++ b/fittrackee/users/models.py
@@ -20,8 +20,10 @@ from sqlalchemy.types import Enum
 
 from fittrackee import BaseModel, appLog, bcrypt, db
 from fittrackee.comments.models import Comment
+from fittrackee.database import TZDateTime
+from fittrackee.dates import aware_utc_now
 from fittrackee.files import get_absolute_file_path
-from fittrackee.utils import TZDateTime, aware_utc_now, encode_uuid
+from fittrackee.utils import encode_uuid
 from fittrackee.visibility_levels import VisibilityLevel
 from fittrackee.workouts.models import Workout
 

--- a/fittrackee/users/models.py
+++ b/fittrackee/users/models.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from uuid import uuid4
 
@@ -21,7 +21,7 @@ from sqlalchemy.types import Enum
 from fittrackee import BaseModel, appLog, bcrypt, db
 from fittrackee.comments.models import Comment
 from fittrackee.files import get_absolute_file_path
-from fittrackee.utils import encode_uuid
+from fittrackee.utils import TZDateTime, aware_utc_now, encode_uuid
 from fittrackee.visibility_levels import VisibilityLevel
 from fittrackee.workouts.models import Workout
 
@@ -64,10 +64,8 @@ class FollowRequest(BaseModel):
         primary_key=True,
     )
     is_approved = db.Column(db.Boolean, default=False, nullable=False)
-    created_at = db.Column(
-        db.DateTime, nullable=False, default=datetime.utcnow
-    )
-    updated_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(TZDateTime, nullable=False, default=aware_utc_now)
+    updated_at = db.Column(TZDateTime, nullable=True)
 
     def __repr__(self) -> str:
         return (
@@ -151,7 +149,7 @@ def on_follow_request_update(
                         follow_notification = Notification(
                             from_user_id=follow_request.follower_user_id,
                             to_user_id=follow_request.followed_user_id,
-                            created_at=datetime.utcnow(),
+                            created_at=datetime.now(timezone.utc),
                             event_type='follow',
                         )
                         session.add(follow_notification)
@@ -162,7 +160,7 @@ def on_follow_request_update(
                     notification = Notification(
                         from_user_id=follow_request.followed_user_id,
                         to_user_id=follow_request.follower_user_id,
-                        created_at=datetime.utcnow(),
+                        created_at=datetime.now(timezone.utc),
                         event_type='follow_request_approved',
                     )
                     session.add(notification)
@@ -215,7 +213,7 @@ class BlockedUser(BaseModel):
         db.ForeignKey('users.id', ondelete='CASCADE'),
         index=True,
     )
-    created_at = db.Column(db.DateTime, nullable=False)
+    created_at = db.Column(TZDateTime, nullable=False)
 
     def __init__(
         self,
@@ -226,7 +224,7 @@ class BlockedUser(BaseModel):
         self.user_id = user_id
         self.by_user_id = by_user_id
         self.created_at = (
-            datetime.utcnow() if created_at is None else created_at
+            datetime.now(timezone.utc) if created_at is None else created_at
         )
 
 
@@ -236,10 +234,10 @@ class User(BaseModel):
     username = db.Column(db.String(255), unique=True, nullable=False)
     email = db.Column(db.String(255), unique=True, nullable=False)
     password = db.Column(db.String(255), nullable=False)
-    created_at = db.Column(db.DateTime, nullable=False)
+    created_at = db.Column(TZDateTime, nullable=False)
     first_name = db.Column(db.String(80), nullable=True)
     last_name = db.Column(db.String(80), nullable=True)
-    birth_date = db.Column(db.DateTime, nullable=True)
+    birth_date = db.Column(TZDateTime, nullable=True)
     location = db.Column(db.String(80), nullable=True)
     bio = db.Column(db.String(200), nullable=True)
     picture = db.Column(db.String(255), nullable=True)
@@ -253,7 +251,7 @@ class User(BaseModel):
     email_to_confirm = db.Column(db.String(255), nullable=True)
     confirmation_token = db.Column(db.String(255), nullable=True)
     display_ascent = db.Column(db.Boolean, default=True, nullable=False)
-    accepted_policy_date = db.Column(db.DateTime, nullable=True)
+    accepted_policy_date = db.Column(TZDateTime, nullable=True)
     start_elevation_at_zero = db.Column(
         db.Boolean, default=True, nullable=False
     )
@@ -275,7 +273,7 @@ class User(BaseModel):
         server_default='PRIVATE',
         nullable=False,
     )
-    suspended_at = db.Column(db.DateTime, nullable=True)
+    suspended_at = db.Column(TZDateTime, nullable=True)
     role = db.Column(
         db.Integer,
         CheckConstraint(
@@ -388,7 +386,7 @@ class User(BaseModel):
             password, current_app.config.get('BCRYPT_LOG_ROUNDS')
         ).decode()
         self.created_at = (
-            datetime.utcnow() if created_at is None else created_at
+            datetime.now(timezone.utc) if created_at is None else created_at
         )
 
     @staticmethod
@@ -478,7 +476,7 @@ class User(BaseModel):
         db.session.add(follow_request)
         if not target.manually_approves_followers:
             follow_request.is_approved = True
-            follow_request.updated_at = datetime.utcnow()
+            follow_request.updated_at = datetime.now(timezone.utc)
         db.session.commit()
 
         return follow_request
@@ -515,7 +513,7 @@ class User(BaseModel):
         if follow_request.updated_at is not None:
             raise FollowRequestAlreadyProcessedError()
         follow_request.is_approved = approved
-        follow_request.updated_at = datetime.utcnow()
+        follow_request.updated_at = datetime.now(timezone.utc)
         db.session.commit()
         return follow_request
 
@@ -575,7 +573,7 @@ class User(BaseModel):
             .values(
                 user_id=user.id,
                 by_user_id=self.id,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
             )
             .on_conflict_do_nothing()
         )
@@ -929,7 +927,7 @@ class BlacklistedToken(BaseModel):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     token = db.Column(db.String(500), unique=True, nullable=False)
     expired_at = db.Column(db.Integer, nullable=False)
-    blacklisted_on = db.Column(db.DateTime, nullable=False)
+    blacklisted_on = db.Column(TZDateTime, nullable=False)
 
     def __init__(
         self, token: str, blacklisted_on: Optional[datetime] = None
@@ -942,7 +940,7 @@ class BlacklistedToken(BaseModel):
         self.token = token
         self.expired_at = payload['exp']
         self.blacklisted_on = (
-            blacklisted_on if blacklisted_on else datetime.utcnow()
+            blacklisted_on if blacklisted_on else datetime.now(timezone.utc)
         )
 
     @classmethod
@@ -960,12 +958,8 @@ class UserDataExport(BaseModel):
         index=True,
         unique=True,
     )
-    created_at = db.Column(
-        db.DateTime, nullable=False, default=datetime.utcnow
-    )
-    updated_at = db.Column(
-        db.DateTime, nullable=True, onupdate=datetime.utcnow
-    )
+    created_at = db.Column(TZDateTime, nullable=False, default=aware_utc_now)
+    updated_at = db.Column(TZDateTime, nullable=True, onupdate=aware_utc_now)
     completed = db.Column(db.Boolean, nullable=False, default=False)
     file_name = db.Column(db.String(100), nullable=True)
     file_size = db.Column(db.Integer, nullable=True)
@@ -977,7 +971,7 @@ class UserDataExport(BaseModel):
     ):
         self.user_id = user_id
         self.created_at = (
-            datetime.utcnow() if created_at is None else created_at
+            datetime.now(timezone.utc) if created_at is None else created_at
         )
 
     def serialize(self) -> Dict:
@@ -1037,7 +1031,7 @@ class Notification(BaseModel):
         db.ForeignKey('users.id', ondelete='CASCADE'),
         index=True,
     )
-    created_at = db.Column(db.DateTime, nullable=False)
+    created_at = db.Column(TZDateTime, nullable=False)
     marked_as_read = db.Column(db.Boolean, nullable=False, default=False)
     event_object_id = db.Column(db.Integer, nullable=True)
     event_type = db.Column(db.String(50), nullable=False)

--- a/fittrackee/users/users.py
+++ b/fittrackee/users/users.py
@@ -6,6 +6,7 @@ from flask import Blueprint, current_app, request, send_file
 from sqlalchemy import and_, asc, desc, exc, func, nullslast, or_
 
 from fittrackee import appLog, db, limiter
+from fittrackee.dates import get_readable_duration
 from fittrackee.emails.tasks import (
     email_updated_to_new_address,
     password_change_email,
@@ -14,6 +15,7 @@ from fittrackee.emails.tasks import (
 from fittrackee.equipments.models import Equipment
 from fittrackee.files import get_absolute_file_path
 from fittrackee.oauth2.server import require_auth
+from fittrackee.reports.models import ReportAction
 from fittrackee.responses import (
     ForbiddenErrorResponse,
     HttpResponse,
@@ -22,11 +24,9 @@ from fittrackee.responses import (
     UserNotFoundErrorResponse,
     handle_error_and_return_response,
 )
-from fittrackee.utils import get_readable_duration
 from fittrackee.visibility_levels import VisibilityLevel
 from fittrackee.workouts.models import Record, Workout, WorkoutSegment
 
-from ..reports.models import ReportAction
 from .exceptions import (
     BlockUserException,
     FollowRequestAlreadyRejectedError,

--- a/fittrackee/users/users_service.py
+++ b/fittrackee/users/users_service.py
@@ -1,5 +1,5 @@
 import secrets
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Tuple
 
 from sqlalchemy import func
@@ -129,7 +129,7 @@ class UserManagerService:
             self._update_user_email(user, new_email, with_confirmation)
             user_updated = True
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         if suspended is True:
             if user.suspended_at:
                 raise UserAlreadySuspendedException()

--- a/fittrackee/users/utils/token.py
+++ b/fittrackee/users/utils/token.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import jwt
@@ -23,7 +23,7 @@ def get_user_token(
         if password_reset
         else current_app.config['TOKEN_EXPIRATION_SECONDS']
     )
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     payload = {
         'exp': now
         + timedelta(days=expiration_days, seconds=expiration_seconds),

--- a/fittrackee/utils.py
+++ b/fittrackee/utils.py
@@ -1,100 +1,11 @@
 import time
-from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
-import humanize
 import nh3
-import pytz
 import shortuuid
-from babel.dates import format_datetime
-from sqlalchemy import DateTime
 from sqlalchemy.sql import text
-from sqlalchemy.types import TypeDecorator
 
 from fittrackee import db
-from fittrackee.languages import LANGUAGES_DATE_STRING
-from fittrackee.users.constants import USER_DATE_FORMAT, USER_TIMEZONE
-from fittrackee.users.utils.language import get_language
-
-if TYPE_CHECKING:
-    from sqlalchemy.engine.interfaces import Dialect
-
-    from fittrackee.users.models import User
-
-
-# Store Timezone Aware Timestamps as Timezone Naive UTC
-# source: https://docs.sqlalchemy.org/en/14/core/custom_types.html#store-timezone-aware-timestamps-as-timezone-naive-utc  # noqa
-class TZDateTime(TypeDecorator):
-    impl = DateTime
-    cache_ok = True
-
-    def process_bind_param(
-        self, value: Optional[datetime], dialect: 'Dialect'
-    ) -> Optional[datetime]:
-        if value is not None:
-            if not value.tzinfo or value.tzinfo.utcoffset(value) is None:
-                raise TypeError("tzinfo is required")
-            value = value.astimezone(timezone.utc).replace(tzinfo=None)
-        return value
-
-    def process_result_value(
-        self, value: Optional[datetime], dialect: 'Dialect'
-    ) -> Optional[datetime]:
-        if value is not None:
-            value = value.replace(tzinfo=timezone.utc)
-        return value
-
-
-def get_date_string_for_user(date_to_format: datetime, user: "User") -> str:
-    """
-    Note: date_to_format is a timezone-aware datetime in UTC
-    """
-    user_language = get_language(user.language)
-    user_timezone = user.timezone if user.timezone else USER_TIMEZONE
-    user_date_format = (
-        user.date_format if user.date_format else USER_DATE_FORMAT
-    )
-
-    date_format = (
-        LANGUAGES_DATE_STRING[user_language]
-        if user_date_format == "date_string"
-        else user_date_format
-    )
-    return format_datetime(
-        date_to_format.astimezone(pytz.timezone(user_timezone)),
-        format=f"{date_format} - HH:mm:ss",
-        locale=user_language,
-    )
-
-
-def get_readable_duration(duration: int, locale: Optional[str] = None) -> str:
-    """
-    Return readable and localized duration from duration in seconds
-    """
-    if locale is None:
-        locale = 'en'
-    if locale != 'en':
-        try:
-            _t = humanize.i18n.activate(locale)  # noqa
-        except FileNotFoundError:
-            locale = 'en'
-    readable_duration = humanize.naturaldelta(timedelta(seconds=duration))
-    if locale != 'en':
-        humanize.i18n.deactivate()
-    return readable_duration
-
-
-def aware_utc_now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def get_datetime_in_utc(
-    date_string: str, date_format: str = '%Y-%m-%d'
-) -> datetime:
-    return datetime.strptime(date_string, date_format).replace(
-        tzinfo=timezone.utc
-    )
 
 
 def clean(sql: str, days: int) -> int:
@@ -118,10 +29,10 @@ def decode_short_id(short_id: str) -> UUID:
     return shortuuid.decode(short_id)
 
 
-def clean_input(text: str) -> str:
+def clean_input(input_text: str) -> str:
     # HTML sanitization
     return nh3.clean(
-        text,
+        input_text,
         tags={"a", "br", "p", "span"},
         attributes={"a": {"href", "target"}},
     )

--- a/fittrackee/utils.py
+++ b/fittrackee/utils.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
@@ -8,7 +8,9 @@ import nh3
 import pytz
 import shortuuid
 from babel.dates import format_datetime
+from sqlalchemy import DateTime
 from sqlalchemy.sql import text
+from sqlalchemy.types import TypeDecorator
 
 from fittrackee import db
 from fittrackee.languages import LANGUAGES_DATE_STRING
@@ -16,12 +18,37 @@ from fittrackee.users.constants import USER_DATE_FORMAT, USER_TIMEZONE
 from fittrackee.users.utils.language import get_language
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine.interfaces import Dialect
+
     from fittrackee.users.models import User
+
+
+# Store Timezone Aware Timestamps as Timezone Naive UTC
+# source: https://docs.sqlalchemy.org/en/14/core/custom_types.html#store-timezone-aware-timestamps-as-timezone-naive-utc  # noqa
+class TZDateTime(TypeDecorator):
+    impl = DateTime
+    cache_ok = True
+
+    def process_bind_param(
+        self, value: Optional[datetime], dialect: 'Dialect'
+    ) -> Optional[datetime]:
+        if value is not None:
+            if not value.tzinfo or value.tzinfo.utcoffset(value) is None:
+                raise TypeError("tzinfo is required")
+            value = value.astimezone(timezone.utc).replace(tzinfo=None)
+        return value
+
+    def process_result_value(
+        self, value: Optional[datetime], dialect: 'Dialect'
+    ) -> Optional[datetime]:
+        if value is not None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value
 
 
 def get_date_string_for_user(date_to_format: datetime, user: "User") -> str:
     """
-    Note: date_to_format is a naive datetime
+    Note: date_to_format is a timezone-aware datetime in UTC
     """
     user_language = get_language(user.language)
     user_timezone = user.timezone if user.timezone else USER_TIMEZONE
@@ -35,9 +62,7 @@ def get_date_string_for_user(date_to_format: datetime, user: "User") -> str:
         else user_date_format
     )
     return format_datetime(
-        pytz.utc.localize(date_to_format).astimezone(
-            pytz.timezone(user_timezone)
-        ),
+        date_to_format.astimezone(pytz.timezone(user_timezone)),
         format=f"{date_format} - HH:mm:ss",
         locale=user_language,
     )
@@ -58,6 +83,18 @@ def get_readable_duration(duration: int, locale: Optional[str] = None) -> str:
     if locale != 'en':
         humanize.i18n.deactivate()
     return readable_duration
+
+
+def aware_utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def get_datetime_in_utc(
+    date_string: str, date_format: str = '%Y-%m-%d'
+) -> datetime:
+    return datetime.strptime(date_string, date_format).replace(
+        tzinfo=timezone.utc
+    )
 
 
 def clean(sql: str, days: int) -> int:

--- a/fittrackee/workouts/models.py
+++ b/fittrackee/workouts/models.py
@@ -1,5 +1,5 @@
-import datetime
 import os
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 from uuid import UUID, uuid4
@@ -17,7 +17,7 @@ from fittrackee import BaseModel, appLog, db
 from fittrackee.comments.models import Comment
 from fittrackee.equipments.models import WorkoutEquipment
 from fittrackee.files import get_absolute_file_path
-from fittrackee.utils import encode_uuid
+from fittrackee.utils import TZDateTime, aware_utc_now, encode_uuid
 from fittrackee.visibility_levels import (
     VisibilityLevel,
     can_view,
@@ -113,8 +113,8 @@ def update_records(
 
 
 def format_value(
-    value: Union[Decimal, datetime.timedelta], attribute: str
-) -> Union[float, datetime.timedelta]:
+    value: Union[Decimal, timedelta], attribute: str
+) -> Union[float, timedelta]:
     return float(value) if attribute == 'distance' else value  # type: ignore
 
 
@@ -240,11 +240,9 @@ class Workout(BaseModel):
     )
     title = db.Column(db.String(TITLE_MAX_CHARACTERS), nullable=True)
     gpx = db.Column(db.String(255), nullable=True)
-    creation_date = db.Column(db.DateTime, default=datetime.datetime.utcnow)
-    modification_date = db.Column(
-        db.DateTime, onupdate=datetime.datetime.utcnow
-    )
-    workout_date = db.Column(db.DateTime, index=True, nullable=False)
+    creation_date = db.Column(TZDateTime, default=aware_utc_now)
+    modification_date = db.Column(TZDateTime, onupdate=aware_utc_now)
+    workout_date = db.Column(TZDateTime, index=True, nullable=False)
     duration = db.Column(db.Interval, nullable=False)
     pauses = db.Column(db.Interval, nullable=True)
     moving = db.Column(db.Interval, nullable=True)
@@ -274,7 +272,7 @@ class Workout(BaseModel):
         server_default='PRIVATE',
         nullable=False,
     )
-    suspended_at = db.Column(db.DateTime, nullable=True)
+    suspended_at = db.Column(TZDateTime, nullable=True)
     analysis_visibility = db.Column(
         Enum(VisibilityLevel, name='visibility_levels'),
         server_default='PRIVATE',
@@ -318,9 +316,9 @@ class Workout(BaseModel):
         self,
         user_id: int,
         sport_id: int,
-        workout_date: datetime.datetime,
+        workout_date: datetime,
         distance: float,
-        duration: datetime.timedelta,
+        duration: timedelta,
     ) -> None:
         self.user_id = user_id
         self.sport_id = sport_id
@@ -573,8 +571,15 @@ class Workout(BaseModel):
             return workout
 
         if is_owner:
-            date_from = params.get('from') if params else None
-            date_to = params.get('to') if params else None
+            if params and user:
+                from .utils.workouts import get_datetime_from_request_args
+
+                date_from, date_to = get_datetime_from_request_args(
+                    params, user
+                )
+            else:
+                date_from, date_to = (None, None)
+
             distance_from = params.get('distance_from') if params else None
             distance_to = params.get('distance_to') if params else None
             duration_from = params.get('duration_from') if params else None
@@ -590,18 +595,8 @@ class Workout(BaseModel):
                     Workout.user_id == self.user_id,
                     Workout.sport_id == sport_id if sport_id else True,
                     Workout.workout_date <= self.workout_date,
-                    (
-                        Workout.workout_date
-                        >= datetime.datetime.strptime(date_from, '%Y-%m-%d')
-                        if date_from
-                        else True
-                    ),
-                    (
-                        Workout.workout_date
-                        <= datetime.datetime.strptime(date_to, '%Y-%m-%d')
-                        if date_to
-                        else True
-                    ),
+                    Workout.workout_date >= date_from if date_from else True,
+                    Workout.workout_date <= date_to if date_to else True,
                     (
                         Workout.distance >= float(distance_from)
                         if distance_from
@@ -652,18 +647,8 @@ class Workout(BaseModel):
                     Workout.user_id == self.user_id,
                     Workout.sport_id == sport_id if sport_id else True,
                     Workout.workout_date >= self.workout_date,
-                    (
-                        Workout.workout_date
-                        >= datetime.datetime.strptime(date_from, '%Y-%m-%d')
-                        if date_from
-                        else True
-                    ),
-                    (
-                        Workout.workout_date
-                        <= datetime.datetime.strptime(date_to, '%Y-%m-%d')
-                        if date_to
-                        else True
-                    ),
+                    Workout.workout_date >= date_from if date_from else True,
+                    Workout.workout_date <= date_to if date_to else True,
                     (
                         Workout.distance >= float(distance_from)
                         if distance_from
@@ -900,7 +885,7 @@ class Record(BaseModel):
     )
     workout_uuid = db.Column(postgresql.UUID(as_uuid=True), nullable=False)
     record_type = db.Column(Enum(*record_types, name="record_types"))
-    workout_date = db.Column(db.DateTime, nullable=False)
+    workout_date = db.Column(TZDateTime, nullable=False)
     _value = db.Column("value", db.Integer, nullable=True)
 
     def __str__(self) -> str:
@@ -919,11 +904,11 @@ class Record(BaseModel):
         self.workout_date = workout.workout_date
 
     @hybrid_property
-    def value(self) -> Optional[Union[datetime.timedelta, float]]:
+    def value(self) -> Optional[Union[timedelta, float]]:
         if self._value is None:
             return None
         if self.record_type == 'LD':
-            return datetime.timedelta(seconds=self._value)
+            return timedelta(seconds=self._value)
         elif self.record_type in ['AS', 'MS']:
             return float(self._value / 100)
         else:  # 'FD' or 'HA'
@@ -982,7 +967,7 @@ class WorkoutLike(BaseModel):
         ),
     )
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    created_at = db.Column(db.DateTime, nullable=False)
+    created_at = db.Column(TZDateTime, nullable=False)
     user_id = db.Column(
         db.Integer,
         db.ForeignKey('users.id', ondelete='CASCADE'),
@@ -1002,12 +987,12 @@ class WorkoutLike(BaseModel):
         self,
         user_id: int,
         workout_id: int,
-        created_at: Optional[datetime.datetime] = None,
+        created_at: Optional[datetime] = None,
     ) -> None:
         self.user_id = user_id
         self.workout_id = workout_id
         self.created_at = (
-            datetime.datetime.utcnow() if created_at is None else created_at
+            datetime.now(timezone.utc) if created_at is None else created_at
         )
 
 

--- a/fittrackee/workouts/models.py
+++ b/fittrackee/workouts/models.py
@@ -15,9 +15,11 @@ from sqlalchemy.types import JSON, Enum
 
 from fittrackee import BaseModel, appLog, db
 from fittrackee.comments.models import Comment
+from fittrackee.database import TZDateTime
+from fittrackee.dates import aware_utc_now
 from fittrackee.equipments.models import WorkoutEquipment
 from fittrackee.files import get_absolute_file_path
-from fittrackee.utils import TZDateTime, aware_utc_now, encode_uuid
+from fittrackee.utils import encode_uuid
 from fittrackee.visibility_levels import (
     VisibilityLevel,
     can_view,
@@ -31,9 +33,8 @@ if TYPE_CHECKING:
     from sqlalchemy.orm.attributes import AttributeEvent
 
     from fittrackee.equipments.models import Equipment
+    from fittrackee.reports.models import ReportAction
     from fittrackee.users.models import User
-
-    from ..reports.models import ReportAction
 
 
 EMPTY_MINIMAL_WORKOUT_VALUES: Dict = {

--- a/fittrackee/workouts/stats.py
+++ b/fittrackee/workouts/stats.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Dict, List, Union
 
 from flask import Blueprint, current_app, request
@@ -17,6 +17,7 @@ from fittrackee.responses import (
 from fittrackee.users.models import User
 from fittrackee.users.roles import UserRole
 
+from ..utils import get_datetime_in_utc
 from .models import Sport, Workout
 from .utils.uploads import get_upload_dir_size
 from .utils.workouts import get_average_speed, get_datetime_from_request_args
@@ -270,7 +271,7 @@ def get_workouts_by_time(
             date_key = row[7]
             if time and time.startswith("week"):
                 date_key = (
-                    datetime.strptime(date_key + '-1', "%G-%V-%u") - delta
+                    get_datetime_in_utc(date_key + '-1', "%G-%V-%u") - delta
                 ).strftime('%Y-%m-%d')
             sport_key = row[0]
             if date_key not in statistics:

--- a/fittrackee/workouts/stats.py
+++ b/fittrackee/workouts/stats.py
@@ -5,6 +5,7 @@ from flask import Blueprint, current_app, request
 from sqlalchemy import func
 
 from fittrackee import db
+from fittrackee.dates import get_datetime_in_utc
 from fittrackee.oauth2.server import require_auth
 from fittrackee.responses import (
     ForbiddenErrorResponse,
@@ -17,7 +18,6 @@ from fittrackee.responses import (
 from fittrackee.users.models import User
 from fittrackee.users.roles import UserRole
 
-from ..utils import get_datetime_in_utc
 from .models import Sport, Workout
 from .utils.uploads import get_upload_dir_size
 from .utils.workouts import get_average_speed, get_datetime_from_request_args

--- a/fittrackee/workouts/workouts.py
+++ b/fittrackee/workouts/workouts.py
@@ -22,12 +22,13 @@ from fittrackee.equipments.exceptions import (
     InvalidEquipmentException,
     InvalidEquipmentsException,
 )
-from fittrackee.equipments.models import Equipment
+from fittrackee.equipments.models import Equipment, WorkoutEquipment
 from fittrackee.equipments.utils import (
     SPORT_EQUIPMENT_TYPES,
     handle_equipments,
 )
 from fittrackee.oauth2.server import require_auth
+from fittrackee.reports.models import ReportActionAppeal
 from fittrackee.responses import (
     DataInvalidPayloadErrorResponse,
     DataNotFoundErrorResponse,
@@ -44,9 +45,8 @@ from fittrackee.users.models import User, UserSportPreference
 from fittrackee.utils import decode_short_id
 from fittrackee.visibility_levels import can_view
 
-from ..reports.models import ReportActionAppeal
 from .decorators import check_workout
-from .models import Sport, Workout, WorkoutEquipment, WorkoutLike
+from .models import Sport, Workout, WorkoutLike
 from .utils.convert import convert_in_duration
 from .utils.gpx import (
     WorkoutGPXException,


### PR DESCRIPTION
see https://github.com/SamR1/FitTrackee/issues/599

Timestamps in database remain store without timezone.
A `TypeDecorator` recipe is used to handle datetime with timezone: 
https://docs.sqlalchemy.org/en/14/core/custom_types.html#store-timezone-aware-timestamps-as-timezone-naive-utc