### PR TITLE
Fix tasks queue running on Python 3.13

### DIFF
--- a/.env.docker.dev
+++ b/.env.docker.dev
@@ -20,13 +20,16 @@ export REDIS_URL=redis://redis:6379
 # API rate limits
 # export API_RATE_LIMITS="300 per 5 minutes"
 
+# Dramatiq Tasks (for user data export and email sending)
+export WORKERS_PROCESSES=2
+# export DRAMATIQ_LOG=
+
 # Emails
 export UI_URL=http://0.0.0.0:5000
 # For development:
 # export UI_URL=http://0.0.0.0:3000
 export EMAIL_URL=smtp://mail:1025
 export SENDER_EMAIL=fittrackee@example.com
-export WORKERS_PROCESSES=2
 
 # Workouts
 # export TILE_SERVER_URL=

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -22,7 +22,7 @@ export POSTGRES_PASSWORD=
 export POSTGRES_DB=fittrackee
 export DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@fittrackee-db:5432/${POSTGRES_DB}
 
-# Redis (required for API rate limits and email sending)
+# Redis (required for API rate limits, user data export and email sending)
 export REDIS_URL=redis://redis:6379
 
 # API rate limits

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ export UPLOAD_FOLDER=
 
 # Dramatiq Tasks (for user data export and email sending)
 # export WORKERS_PROCESSES=
-# export DRAMATIQ_LOG=
+export DRAMATIQ_LOG=dramatiq.log
 
 # Emails
 export UI_URL=

--- a/.env.example
+++ b/.env.example
@@ -16,17 +16,20 @@ export UPLOAD_FOLDER=
 # PostgreSQL
 # export DATABASE_URL=postgresql://fittrackee:fittrackee@${HOST}:5432/fittrackee
 
-# Redis (required for API rate limits and email sending)
+# Redis (required for API rate limits, user data export and email sending)
 # export REDIS_URL=
 
 # API rate limits
-# export API_RATE_LIMITS="300 per 5 minutes"
+# export API_RATE_LIMITS=300 per 5 minutes
+
+# Dramatiq Tasks (for user data export and email sending)
+# export WORKERS_PROCESSES=
+# export DRAMATIQ_LOG=
 
 # Emails
 export UI_URL=
 export EMAIL_URL=
 export SENDER_EMAIL=
-# export WORKERS_PROCESSES=
 
 # Workouts
 # export TILE_SERVER_URL=

--- a/.github/workflows/.e2e-tests.yml
+++ b/.github/workflows/.e2e-tests.yml
@@ -82,5 +82,5 @@ jobs:
           setsid nohup fittrackee >> nohup.out 2>&1 &
           export TEST_APP_URL=http://$(hostname --ip-address):5000
           sleep 5
-          nohup flask worker --processes=1 >> nohup.out 2>&1 &
+          nohup dramatiq fittrackee.tasks:broker --processes=1 >> nohup.out 2>&1 &
           pytest e2e --driver Remote --capability browserName firefox --selenium-host selenium --selenium-port 4444 --maxfail=1

--- a/.github/workflows/.tests-and-publish-python.yml
+++ b/.github/workflows/.tests-and-publish-python.yml
@@ -147,7 +147,7 @@ jobs:
           setsid nohup flask run --with-threads -h 0.0.0.0 -p 5000 >> nohup.out 2>&1 &
           export TEST_APP_URL=http://$(hostname --ip-address):5000
           sleep 5
-          nohup flask worker --processes=1 >> nohup.out 2>&1 &
+          nohup dramatiq fittrackee.tasks:broker --processes=1 >> nohup.out 2>&1 &
           pytest e2e --driver Remote --capability browserName firefox --selenium-host selenium --selenium-port 4444 --maxfail=1
 
   build_package:

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ run-server:
 	cd fittrackee && $(GUNICORN) -b $(HOST):$(PORT) "fittrackee:create_app()" --error-logfile ../gunicorn.log
 
 run-workers:
-	$(DRAMATIQ) fittrackee.tasks:broker --processes=$(WORKERS_PROCESSES) --log-file=dramatiq.log
+	$(DRAMATIQ) fittrackee.tasks:broker --processes=$(WORKERS_PROCESSES) --log-file=$(DRAMATIQ_LOG)
 
 serve:
     # for dev environments

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ run-server:
 	cd fittrackee && $(GUNICORN) -b $(HOST):$(PORT) "fittrackee:create_app()" --error-logfile ../gunicorn.log
 
 run-workers:
-	$(FLASK) worker --processes=$(WORKERS_PROCESSES) >> dramatiq.log  2>&1
+	$(DRAMATIQ) fittrackee.tasks:broker --processes=$(WORKERS_PROCESSES) --log-file=dramatiq.log
 
 serve:
     # for dev environments

--- a/Makefile.config
+++ b/Makefile.config
@@ -26,6 +26,7 @@ MYPY = $(VENV)/bin/mypy
 BANDIT = $(VENV)/bin/bandit
 PYBABEL = $(VENV)/bin/pybabel
 FTCLI = $(VENV)/bin/ftcli
+DRAMATIQ = $(VENV)/bin/dramatiq
 
 # Docker env
 export DOCKER_APP_DIR = /usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - internal_network
     restart: unless-stopped
 
-# Uncomment the following lines for email sending
+# Uncomment the following lines for user data export and email sending
 #  fittrackee-workers:
 #    container_name: fittrackee-workers
 #    env_file:
@@ -71,7 +71,8 @@ services:
 #    post_start:
 #      - command: chown -R fittrackee:fittrackee /usr/src/app/logs
 #        user: root
-#    command: "flask worker --processes 2 >> /usr/src/app/logs/dramatiq.log 2>&1"
+## Adjust processes if needed, see https://dramatiq.io/guide.html#workers
+#    command: "dramatiq fittrackee.tasks:broker --processes=2 --log-file=/usr/src/app/logs/dramatiq.log"
 #    depends_on:
 #      fittrackee:
 #        condition: service_healthy
@@ -80,7 +81,7 @@ services:
 #      - external_network
 #    restart: unless-stopped
 
-# Uncomment the following lines for API rate limit and email sending
+# Uncomment the following lines for API rate limit, user data export and email sending
 #  fittrackee-redis:
 #    image: "redis:7.4"
 #    container_name: fittrackee-redis

--- a/docker-entrypoint-dev.sh
+++ b/docker-entrypoint-dev.sh
@@ -7,7 +7,7 @@ ftcli db upgrade || { echo "Failed to upgrade database!"; exit 1; }
 
 # Run workers
 echo "Starting workers..."
-flask worker --processes="${WORKERS_PROCESSES:-1}" >> data/logs/dramatiq.log 2>&1 &
+dramatiq fittrackee.tasks:broker --processes="${WORKERS_PROCESSES:-1}" --log-file="${DRAMATIQ_LOG:-data/logs/dramatiq.log}" &
 
 # Wait for workers to start
 sleep 3

--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -214,6 +214,13 @@ deployment method.
     Number of processes used by **Dramatiq**.
 
 
+.. envvar:: DRAMATIQ_LOG
+
+    .. versionadded:: 0.9.5
+
+    Path to **Dramatiq** log file.
+
+
 .. envvar:: API_RATE_LIMITS
 
     .. versionadded:: 0.7.0
@@ -517,11 +524,20 @@ For instance, copy and update ``.env`` file from ``.env.example`` and source the
 
     $ fittrackee
 
-- Start task queue workers **if email sending is enabled**, with flask-dramatiq CLI:
+- Start task queue workers **if email sending is enabled**, with dramatiq CLI:
 
 .. code-block:: bash
 
-    $ flask worker --processes 2
+    $ dramatiq fittrackee.tasks:broker --processes=$WORKERS_PROCESSES --log-file=$DRAMATIQ_LOG
+
+.. note::
+    | It is also possible to start task queue workers with Flask-dramatiq CLI:
+
+    .. code-block:: bash
+
+        $ flask worker --processes 2
+
+    | But running Flask-dramatiq CLI on Python 3.13+ raises errors. Emails and user data export are sent, but the `middleware <https://dramatiq.io/reference.html#dramatiq.middleware.TimeLimit>`__ preventing actors from running too long is not active. Please use dramatiq CLI instead for now.
 
 .. note::
     | To start application and workers with **systemd** service, see `Deployment <installation.html#deployment>`__
@@ -857,7 +873,7 @@ Examples:
     Environment="SENDER_EMAIL="
     Environment="REDIS_URL="
     WorkingDirectory=/home/<USER>/<FITTRACKEE DIRECTORY>
-    ExecStart=/home/<USER>/<FITTRACKEE DIRECTORY>/.venv/bin/flask worker --processes <NUMBER OF PROCESSES>
+    ExecStart=/home/<USER>/<FITTRACKEE DIRECTORY>/.venv/bin/dramatiq fittrackee.tasks:broker --processes=<NUMBER OF PROCESSES> --log-file=<DRAMATIQ_LOG_FILE_PATH>
     Restart=always
 
     [Install]

--- a/fittrackee/tasks.py
+++ b/fittrackee/tasks.py
@@ -1,0 +1,4 @@
+from fittrackee import create_app, dramatiq
+
+app = create_app()
+broker = dramatiq.broker


### PR DESCRIPTION
When running task queue workers with [Flask-dramatiq](https://flask-dramatiq.readthedocs.io) CLI, an error occurs with [TimeLimit](https://dramatiq.io/reference.html#dramatiq.middleware.TimeLimit) middleware:

```python
2025/04/06 06:57:58 - dramatiq.broker.RedisBroker - CRITICAL - Unexpected failure in after_process_boot of <dramatiq.middleware.time_limit.TimeLimit object at 0x714f79459a90>.
Traceback (most recent call last):
  File "/opt/venv/lib/python3.13/site-packages/dramatiq/broker.py", line 115, in emit_after
    getattr(middleware, signal)(self, *args, **kwargs)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.13/site-packages/dramatiq/middleware/time_limit.py", line 72, in after_process_boot
    self.manager.start()
    ~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/threading.py", line 973, in start
    _start_joinable_thread(self._bootstrap, handle=self._handle,
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                           daemon=self.daemon)
                           ^^^^^^^^^^^^^^^^^^^
RuntimeError: thread already started
```
see issue: https://gitlab.com/bersace/flask-dramatiq/-/issues/14

The actors are running (it is still possible to send emails or request a data export), but the middleware is not active.

The workaround is to use [Dramatiq](https://dramatiq.io/index.html) CLI directly.
This PR allows it by making broker available.

Example:
```
$ dramatiq fittrackee.tasks:broker --processes=2 --log-file=dramatiq.log
```

