### PR TITLE
Init TCX support

### DIFF
--- a/fittrackee/config.py
+++ b/fittrackee/config.py
@@ -33,7 +33,7 @@ class BaseConfig:
         os.getenv("UPLOAD_FOLDER", current_app.root_path), "uploads"
     )
     PICTURE_ALLOWED_EXTENSIONS = {"jpg", "png", "gif"}
-    WORKOUT_ALLOWED_EXTENSIONS = {"gpx", "kml", "kmz", "zip"}
+    WORKOUT_ALLOWED_EXTENSIONS = {"gpx", "kml", "kmz", "tcx", "zip"}
     TEMPLATES_FOLDER = os.path.join(current_app.root_path, "emails/templates")
     UI_URL = os.environ["UI_URL"]
     EMAIL_URL = os.environ.get("EMAIL_URL")

--- a/fittrackee/tests/fixtures/fixtures_workouts.py
+++ b/fittrackee/tests/fixtures/fixtures_workouts.py
@@ -1269,6 +1269,16 @@ def invalid_tcx_file() -> str:
 
 
 @pytest.fixture()
+def tcx_file_wo_activities() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase
+        xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd">
+</TrainingCenterDatabase>"""
+
+
+@pytest.fixture()
 def tcx_file_wo_laps() -> str:
     return """<?xml version="1.0" encoding="UTF-8"?>
 <TrainingCenterDatabase
@@ -1603,6 +1613,41 @@ def tcx_with_with_two_laps() -> str:
         + """
                 </Track>
             </Lap>
+            <Lap StartTime="2018-03-13T12:46:30Z">
+                <Track>
+"""
+        + tcx_track_points_part_2
+        + """
+                </Track>
+            </Lap>
+        </Activity>
+    </Activities>
+</TrainingCenterDatabase>
+"""
+    )
+
+
+@pytest.fixture()
+def tcx_with_with_two_activities() -> str:
+    return (
+        """<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase
+        xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd">
+    <Activities>
+        <Activity Sport="Other">
+            <Id>2018-03-13T12:44:45Z</Id>
+            <Lap StartTime="2018-03-13T12:44:45Z">
+                <Track>
+"""
+        + tcx_track_points_part_1
+        + """
+                </Track>
+            </Lap>
+        </Activity>
+        <Activity Sport="Biking">
+            <Id>2018-03-13T12:46:30Z</Id>
             <Lap StartTime="2018-03-13T12:46:30Z">
                 <Track>
 """

--- a/fittrackee/tests/fixtures/fixtures_workouts.py
+++ b/fittrackee/tests/fixtures/fixtures_workouts.py
@@ -16,7 +16,7 @@ from fittrackee.workouts.models import (
     Workout,
     WorkoutSegment,
 )
-from fittrackee.workouts.services.workout_from_file.base_workout_with_segment_service import (  # noqa
+from fittrackee.workouts.services.workout_from_file.base_workout_with_segment_service import (
     StaticMap,
 )
 
@@ -462,7 +462,7 @@ track_points_part_2 = (
 def gpx_file() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <name>just a workout</name>"
@@ -479,7 +479,7 @@ def gpx_file() -> str:
 def gpx_file_wo_name() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <trkseg>"
@@ -495,7 +495,7 @@ def gpx_file_wo_name() -> str:
 def gpx_file_with_description() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <name>just a workout</name>"
@@ -513,7 +513,7 @@ def gpx_file_with_description() -> str:
 def gpx_file_with_empty_description() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <name>just a workout</name>"
@@ -531,7 +531,7 @@ def gpx_file_with_empty_description() -> str:
 def gpx_file_with_offset() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <trkseg>"
@@ -645,7 +645,7 @@ def gpx_file_with_offset() -> str:
 def gpx_file_with_microseconds() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <trkseg>"
@@ -761,7 +761,7 @@ def gpx_file_with_microseconds() -> str:
 def gpx_file_without_elevation() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <name>just a workout</name>"
@@ -851,7 +851,7 @@ def gpx_file_without_elevation() -> str:
 def gpx_file_w_title_exceeding_limit() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         f"    <name>{random_string(TITLE_MAX_CHARACTERS + 1)}</name>"
@@ -868,7 +868,7 @@ def gpx_file_w_title_exceeding_limit() -> str:
 def gpx_file_wo_track() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "</gpx>"
     )
@@ -878,7 +878,7 @@ def gpx_file_wo_track() -> str:
 def gpx_file_invalid_xml() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <name>just a workout</name>"
@@ -889,7 +889,7 @@ def gpx_file_invalid_xml() -> str:
 def gpx_file_without_time() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <name>just a workout</name>"
@@ -937,7 +937,7 @@ def gpx_file_without_time() -> str:
 def gpx_file_with_segments() -> str:
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <name>just a workout</name>"
@@ -953,7 +953,7 @@ def gpx_file_with_3_segments() -> str:
     """60 seconds between each segment"""
     return (
         "<?xml version='1.0' encoding='UTF-8'?>"
-        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'  # noqa
+        '<gpx xmlns:gpxdata="http://www.cluetrust.com/XML/GPXDATA/1/0" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxext="http://www.garmin.com/xmlschemas/GpxExtensions/v3" xmlns="http://www.topografix.com/GPX/1/1">'
         "  <metadata/>"
         "  <trk>"
         "    <name>just a workout</name>"
@@ -1023,7 +1023,7 @@ def upload_workouts_archive_mock() -> Iterator[MagicMock]:
 def invalid_kml_file() -> str:
     return (
         '<?xml version="1.0" encoding="UTF-8"?>'
-        '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:opentracks="http://opentracksapp.com/xmlschemas/v1">'  # noqa
+        '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:opentracks="http://opentracksapp.com/xmlschemas/v1">'
         "  <Document>"
         "    <open>1</open>"
     )
@@ -1033,7 +1033,7 @@ def invalid_kml_file() -> str:
 def kml_file_wo_tracks() -> str:
     return (
         '<?xml version="1.0" encoding="UTF-8"?>'
-        '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:opentracks="http://opentracksapp.com/xmlschemas/v1">'  # noqa
+        '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:opentracks="http://opentracksapp.com/xmlschemas/v1">'
         "  <Document>"
         "    <Placemark>"
         "      <name>New York City</name>"
@@ -1108,7 +1108,7 @@ kml_track_points_part_2 = (
 def kml_2_2_with_one_track() -> str:
     return (
         '<?xml version="1.0" encoding="UTF-8"?>'
-        '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:opentracks="http://opentracksapp.com/xmlschemas/v1">'  # noqa
+        '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:opentracks="http://opentracksapp.com/xmlschemas/v1">'
         "  <Document>"
         "    <open>1</open>"
         "    <visibility>1</visibility>"
@@ -1140,7 +1140,7 @@ def kml_2_2_with_one_track() -> str:
         "        <displayName><![CDATA[Cadence (tr/min)]]></displayName>"
         "      </gx:SimpleArrayField>"
         '      <gx:SimpleArrayField name="heart_rate" type="float">'
-        "        <displayName><![CDATA[Fréquence cardiaque (bpm)]]></displayName>"  # noqa
+        "        <displayName><![CDATA[Fréquence cardiaque (bpm)]]></displayName>"
         "      </gx:SimpleArrayField>"
         "    </Schema>"
         "    <Placemark>"
@@ -1173,7 +1173,7 @@ def kml_2_2_with_one_track() -> str:
 def kml_2_2_with_two_tracks() -> str:
     return (
         '<?xml version="1.0" encoding="UTF-8"?>'
-        '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:opentracks="http://opentracksapp.com/xmlschemas/v1">'  # noqa
+        '<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:opentracks="http://opentracksapp.com/xmlschemas/v1">'
         "  <Document>"
         "    <open>1</open>"
         "    <visibility>1</visibility>"
@@ -1205,7 +1205,7 @@ def kml_2_2_with_two_tracks() -> str:
         "        <displayName><![CDATA[Cadence (tr/min)]]></displayName>"
         "      </gx:SimpleArrayField>"
         '      <gx:SimpleArrayField name="heart_rate" type="float">'
-        "        <displayName><![CDATA[Fréquence cardiaque (bpm)]]></displayName>"  # noqa
+        "        <displayName><![CDATA[Fréquence cardiaque (bpm)]]></displayName>"
         "      </gx:SimpleArrayField>"
         "    </Schema>"
         "    <Placemark>"
@@ -1252,4 +1252,366 @@ def kml_2_3_wo_name_and_description(kml_2_2_with_one_track: str) -> str:
         kml_2_2_to_kml_2_3(kml_2_2_with_one_track)
         .replace("<name><![CDATA[just a workout]]></name>", "")
         .replace("<description><![CDATA[some description]]></description>", "")
+    )
+
+
+@pytest.fixture()
+def invalid_tcx_file() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase
+        xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd">
+    <Activities>
+        <Activity Sport="Other">
+            <Id>2018-03-13T12:44:45Z</Id>
+    """
+
+
+@pytest.fixture()
+def tcx_file_wo_laps() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase
+        xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd">
+    <Activities>
+        <Activity Sport="Other">
+            <Id>2018-03-13T12:44:45Z</Id>
+        </Activity>
+    </Activities>
+</TrainingCenterDatabase>"""
+
+
+@pytest.fixture()
+def tcx_file_wo_tracks() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase
+        xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd">
+    <Activities>
+        <Activity Sport="Other">
+            <Id>2018-03-13T12:44:45Z</Id>
+            <Lap StartTime="2018-03-13T12:44:45Z">
+            </Lap>
+        </Activity>
+    </Activities>
+</TrainingCenterDatabase>"""
+
+
+tcx_track_points_part_1 = """        <Trackpoint>
+          <Time>2018-03-13T12:44:45Z</Time>
+          <Position>
+            <LatitudeDegrees>44.68095000</LatitudeDegrees>
+            <LongitudeDegrees>6.073670000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>997.00000</AltitudeMeters>
+          <DistanceMeters>0.000</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:44:50Z</Time>
+          <Position>
+            <LatitudeDegrees>44.68091000</LatitudeDegrees>
+            <LongitudeDegrees>6.073670000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>996.00000</AltitudeMeters>
+          <DistanceMeters>4.449</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:45:00Z</Time>
+          <Position>
+            <LatitudeDegrees>44.68080000</LatitudeDegrees>
+            <LongitudeDegrees>6.073640000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>996.00000</AltitudeMeters>
+          <DistanceMeters>16.908</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:45:05Z</Time>
+          <Position>
+            <LatitudeDegrees>44.68075000</LatitudeDegrees>
+            <LongitudeDegrees>6.073640000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>996.00000</AltitudeMeters>
+          <DistanceMeters>22.467</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:45:10Z</Time>
+          <Position>
+            <LatitudeDegrees>44.68071000</LatitudeDegrees>
+            <LongitudeDegrees>6.073640000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>996.00000</AltitudeMeters>
+          <DistanceMeters>26.914</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:45:30Z</Time>
+          <Position>
+            <LatitudeDegrees>44.68049000</LatitudeDegrees>
+            <LongitudeDegrees>6.073610000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>995.00000</AltitudeMeters>
+          <DistanceMeters>51.492</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:45:55Z</Time>
+          <Position>
+            <LatitudeDegrees>44.68019000</LatitudeDegrees>
+            <LongitudeDegrees>6.073560000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>993.00000</AltitudeMeters>
+          <DistanceMeters>85.083</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:46:00Z</Time>
+          <Position>
+            <LatitudeDegrees>44.68014000</LatitudeDegrees>
+            <LongitudeDegrees>6.073550000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>992.00000</AltitudeMeters>
+          <DistanceMeters>90.698</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:46:15Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67995000</LatitudeDegrees>
+            <LongitudeDegrees>6.073580000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>991.00000</AltitudeMeters>
+          <DistanceMeters>111.958</DistanceMeters>
+        </Trackpoint>"""
+
+
+tcx_track_points_part_2 = """<Trackpoint>
+          <Time>2018-03-13T12:46:30Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67977000</LatitudeDegrees>
+            <LongitudeDegrees>6.073640000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>989.00000</AltitudeMeters>
+          <DistanceMeters>132.527</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:46:35Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67972000</LatitudeDegrees>
+            <LongitudeDegrees>6.073670000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>988.00000</AltitudeMeters>
+          <DistanceMeters>138.572</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:46:40Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67966000</LatitudeDegrees>
+            <LongitudeDegrees>6.073680000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>988.00000</AltitudeMeters>
+          <DistanceMeters>145.290</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:46:45Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67961000</LatitudeDegrees>
+            <LongitudeDegrees>6.073700000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>987.00000</AltitudeMeters>
+          <DistanceMeters>151.071</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:47:05Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67938000</LatitudeDegrees>
+            <LongitudeDegrees>6.073770000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>985.00000</AltitudeMeters>
+          <DistanceMeters>177.238</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:47:10Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67933000</LatitudeDegrees>
+            <LongitudeDegrees>6.073810000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>985.00000</AltitudeMeters>
+          <DistanceMeters>183.635</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:47:20Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67922000</LatitudeDegrees>
+            <LongitudeDegrees>6.073850000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>985.00000</AltitudeMeters>
+          <DistanceMeters>196.269</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:47:30Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67911000</LatitudeDegrees>
+            <LongitudeDegrees>6.073900000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>984.00000</AltitudeMeters>
+          <DistanceMeters>209.123</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:47:40Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67900000</LatitudeDegrees>
+            <LongitudeDegrees>6.073990000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>983.00000</AltitudeMeters>
+          <DistanceMeters>223.274</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:47:45Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67896000</LatitudeDegrees>
+            <LongitudeDegrees>6.074020000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>983.00000</AltitudeMeters>
+          <DistanceMeters>228.315</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:47:55Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67884000</LatitudeDegrees>
+            <LongitudeDegrees>6.074080000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>982.00000</AltitudeMeters>
+          <DistanceMeters>242.477</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:48:15Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67863000</LatitudeDegrees>
+            <LongitudeDegrees>6.074230000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>979.00000</AltitudeMeters>
+          <DistanceMeters>268.667</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:48:20Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67858000</LatitudeDegrees>
+            <LongitudeDegrees>6.074250000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>979.00000</AltitudeMeters>
+          <DistanceMeters>274.448</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:48:35Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67842000</LatitudeDegrees>
+            <LongitudeDegrees>6.074340000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>978.00000</AltitudeMeters>
+          <DistanceMeters>293.610</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:48:40Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67837000</LatitudeDegrees>
+            <LongitudeDegrees>6.074350000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>978.00000</AltitudeMeters>
+          <DistanceMeters>299.225</DistanceMeters>
+        </Trackpoint>
+        <Trackpoint>
+          <Time>2018-03-13T12:48:55Z</Time>
+          <Position>
+            <LatitudeDegrees>44.67822000</LatitudeDegrees>
+            <LongitudeDegrees>6.074420000</LongitudeDegrees>
+          </Position>
+          <AltitudeMeters>976.00000</AltitudeMeters>
+          <DistanceMeters>316.798</DistanceMeters>
+        </Trackpoint>"""
+
+
+@pytest.fixture()
+def tcx_with_one_lap_and_one_track() -> str:
+    return (
+        """<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase
+        xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd">
+    <Activities>
+        <Activity Sport="Other">
+            <Id>2018-03-13T12:44:45Z</Id>
+            <Lap StartTime="2018-03-13T12:44:45Z">
+                <Track>
+"""
+        + tcx_track_points_part_1
+        + tcx_track_points_part_2
+        + """
+                </Track>
+            </Lap>
+        </Activity>
+    </Activities>
+</TrainingCenterDatabase>
+"""
+    )
+
+
+@pytest.fixture()
+def tcx_with_one_lap_and_two_tracks() -> str:
+    return (
+        """<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase
+        xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd">
+    <Activities>
+        <Activity Sport="Other">
+            <Id>2018-03-13T12:44:45Z</Id>
+            <Lap StartTime="2018-03-13T12:44:45Z">
+                <Track>
+"""
+        + tcx_track_points_part_1
+        + """
+                </Track>
+                <Track>
+"""
+        + tcx_track_points_part_2
+        + """
+                </Track>
+            </Lap>
+        </Activity>
+    </Activities>
+</TrainingCenterDatabase>
+"""
+    )
+
+
+@pytest.fixture()
+def tcx_with_with_two_laps() -> str:
+    return (
+        """<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase
+        xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd">
+    <Activities>
+        <Activity Sport="Other">
+            <Id>2018-03-13T12:44:45Z</Id>
+            <Lap StartTime="2018-03-13T12:44:45Z">
+                <Track>
+"""
+        + tcx_track_points_part_1
+        + """
+                </Track>
+            </Lap>
+            <Lap StartTime="2018-03-13T12:46:30Z">
+                <Track>
+"""
+        + tcx_track_points_part_2
+        + """
+                </Track>
+            </Lap>
+        </Activity>
+    </Activities>
+</TrainingCenterDatabase>
+"""
     )

--- a/fittrackee/tests/fixtures/fixtures_workouts.py
+++ b/fittrackee/tests/fixtures/fixtures_workouts.py
@@ -1596,7 +1596,7 @@ def tcx_with_one_lap_and_two_tracks() -> str:
 
 
 @pytest.fixture()
-def tcx_with_with_two_laps() -> str:
+def tcx_with_two_laps() -> str:
     return (
         """<?xml version="1.0" encoding="UTF-8"?>
 <TrainingCenterDatabase
@@ -1628,7 +1628,7 @@ def tcx_with_with_two_laps() -> str:
 
 
 @pytest.fixture()
-def tcx_with_with_two_activities() -> str:
+def tcx_with_two_activities() -> str:
     return (
         """<?xml version="1.0" encoding="UTF-8"?>
 <TrainingCenterDatabase
@@ -1660,3 +1660,104 @@ def tcx_with_with_two_activities() -> str:
 </TrainingCenterDatabase>
 """
     )
+
+
+@pytest.fixture()
+def tcx_with_invalid_elevation() -> str:
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase
+        xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd">
+    <Activities>
+        <Activity Sport="Other">
+            <Id>2018-03-13T12:44:45Z</Id>
+            <Lap StartTime="2018-03-13T12:44:45Z">
+                <Track>
+                    <Trackpoint>
+                      <Time>2018-03-13T12:44:45Z</Time>
+                      <Position>
+                        <LatitudeDegrees>44.68095000</LatitudeDegrees>
+                        <LongitudeDegrees>6.073670000</LongitudeDegrees>
+                      </Position>
+                      <AltitudeMeters>10000.00</AltitudeMeters>
+                      <DistanceMeters>0.000</DistanceMeters>
+                    </Trackpoint>
+                    <Trackpoint>
+                      <Time>2018-03-13T12:44:50Z</Time>
+                      <Position>
+                        <LatitudeDegrees>44.68091000</LatitudeDegrees>
+                        <LongitudeDegrees>6.073670000</LongitudeDegrees>
+                      </Position>
+                      <AltitudeMeters>10000.00</AltitudeMeters>
+                      <DistanceMeters>4.449</DistanceMeters>
+                    </Trackpoint>
+                    <Trackpoint>
+                      <Time>2018-03-13T12:45:00Z</Time>
+                      <Position>
+                        <LatitudeDegrees>44.68080000</LatitudeDegrees>
+                        <LongitudeDegrees>6.073640000</LongitudeDegrees>
+                      </Position>
+                      <AltitudeMeters>11000.00</AltitudeMeters>
+                      <DistanceMeters>16.908</DistanceMeters>
+                    </Trackpoint>
+                    <Trackpoint>
+                      <Time>2018-03-13T12:45:05Z</Time>
+                      <Position>
+                        <LatitudeDegrees>44.68075000</LatitudeDegrees>
+                        <LongitudeDegrees>6.073640000</LongitudeDegrees>
+                      </Position>
+                      <AltitudeMeters>12000.00</AltitudeMeters>
+                      <DistanceMeters>22.467</DistanceMeters>
+                    </Trackpoint>
+                    <Trackpoint>
+                      <Time>2018-03-13T12:45:10Z</Time>
+                      <Position>
+                        <LatitudeDegrees>44.68071000</LatitudeDegrees>
+                        <LongitudeDegrees>6.073640000</LongitudeDegrees>
+                      </Position>
+                      <AltitudeMeters>13000.00</AltitudeMeters>
+                      <DistanceMeters>26.914</DistanceMeters>
+                    </Trackpoint>
+                    <Trackpoint>
+                      <Time>2018-03-13T12:45:30Z</Time>
+                      <Position>
+                        <LatitudeDegrees>44.68049000</LatitudeDegrees>
+                        <LongitudeDegrees>6.073610000</LongitudeDegrees>
+                      </Position>
+                      <AltitudeMeters>-10000.00</AltitudeMeters>
+                      <DistanceMeters>51.492</DistanceMeters>
+                    </Trackpoint>
+                    <Trackpoint>
+                      <Time>2018-03-13T12:45:55Z</Time>
+                      <Position>
+                        <LatitudeDegrees>44.68019000</LatitudeDegrees>
+                        <LongitudeDegrees>6.073560000</LongitudeDegrees>
+                      </Position>
+                      <AltitudeMeters>-12000.00</AltitudeMeters>
+                      <DistanceMeters>85.083</DistanceMeters>
+                    </Trackpoint>
+                    <Trackpoint>
+                      <Time>2018-03-13T12:46:00Z</Time>
+                      <Position>
+                        <LatitudeDegrees>44.68014000</LatitudeDegrees>
+                        <LongitudeDegrees>6.073550000</LongitudeDegrees>
+                      </Position>
+                      <AltitudeMeters>-1200000</AltitudeMeters>
+                      <DistanceMeters>90.698</DistanceMeters>
+                    </Trackpoint>
+                    <Trackpoint>
+                      <Time>2018-03-13T12:46:15Z</Time>
+                      <Position>
+                        <LatitudeDegrees>44.67995000</LatitudeDegrees>
+                        <LongitudeDegrees>6.073580000</LongitudeDegrees>
+                      </Position>
+                      <AltitudeMeters>1200000</AltitudeMeters>
+                      <DistanceMeters>111.958</DistanceMeters>
+                    </Trackpoint>
+                </Track>
+            </Lap>
+        </Activity>
+    </Activities>
+</TrainingCenterDatabase>
+"""

--- a/fittrackee/tests/workouts/mixins.py
+++ b/fittrackee/tests/workouts/mixins.py
@@ -1,6 +1,8 @@
-from typing import Dict
+from io import BytesIO
+from typing import IO, Dict
 
 import pytest
+from werkzeug.datastructures import FileStorage
 
 from fittrackee.workouts.services.workout_from_file import GpxInfo
 
@@ -30,3 +32,17 @@ class WorkoutGpxInfoMixin:
             **updated_data,
         }
         return GpxInfo(**parsed_data)
+
+
+class WorkoutFileMixin:
+    @staticmethod
+    def get_file_storage(
+        content: str, file_name: str = "file.gpx"
+    ) -> "FileStorage":
+        return FileStorage(
+            filename=file_name, stream=BytesIO(str.encode(content))
+        )
+
+    @staticmethod
+    def get_file_content(content: str) -> IO[bytes]:
+        return BytesIO(str.encode(content))

--- a/fittrackee/tests/workouts/test_services/from_file/test_workout_gpx_creation_service.py
+++ b/fittrackee/tests/workouts/test_services/from_file/test_workout_gpx_creation_service.py
@@ -1,11 +1,9 @@
 from datetime import datetime, timedelta, timezone
-from io import BytesIO
-from typing import IO, TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict
 from unittest.mock import MagicMock, call, patch
 
 import gpxpy
 import pytest
-from werkzeug.datastructures import FileStorage
 
 from fittrackee import db
 from fittrackee.tests.fixtures.fixtures_workouts import (
@@ -13,7 +11,10 @@ from fittrackee.tests.fixtures.fixtures_workouts import (
     track_points_part_2_coordinates,
 )
 from fittrackee.tests.mixins import RandomMixin
-from fittrackee.tests.workouts.mixins import WorkoutGpxInfoMixin
+from fittrackee.tests.workouts.mixins import (
+    WorkoutFileMixin,
+    WorkoutGpxInfoMixin,
+)
 from fittrackee.visibility_levels import VisibilityLevel
 from fittrackee.workouts.exceptions import (
     WorkoutExceedingValueException,
@@ -37,23 +38,7 @@ if TYPE_CHECKING:
     from fittrackee.users.models import User
 
 
-class WorkoutGpxCreationServiceTestCase:
-    @staticmethod
-    def get_file_storage(
-        content: str, file_name: str = "file.gpx"
-    ) -> "FileStorage":
-        return FileStorage(
-            filename=file_name, stream=BytesIO(str.encode(content))
-        )
-
-    @staticmethod
-    def get_file_content(content: str) -> IO[bytes]:
-        return BytesIO(str.encode(content))
-
-
-class TestWorkoutGpxCreationServiceParseFile(
-    RandomMixin, WorkoutGpxCreationServiceTestCase
-):
+class TestWorkoutGpxCreationServiceParseFile(RandomMixin, WorkoutFileMixin):
     def test_it_raises_error_when_gpx_file_is_invalid(
         self, app: "Flask", gpx_file_invalid_xml: str
     ) -> None:
@@ -81,9 +66,7 @@ class TestWorkoutGpxCreationServiceParseFile(
             )
 
 
-class TestWorkoutGpxCreationServiceInstantiation(
-    WorkoutGpxCreationServiceTestCase
-):
+class TestWorkoutGpxCreationServiceInstantiation(WorkoutFileMixin):
     def test_it_instantiates_service(
         self,
         app: "Flask",
@@ -142,7 +125,7 @@ class TestWorkoutGpxCreationServiceGetWeatherData:
 
 @pytest.mark.disable_autouse_update_records_patch
 class TestWorkoutGpxCreationServiceProcessFile(
-    WorkoutGpxInfoMixin, WorkoutGpxCreationServiceTestCase
+    WorkoutGpxInfoMixin, WorkoutFileMixin
 ):
     @staticmethod
     def assert_workout(

--- a/fittrackee/tests/workouts/test_services/from_file/test_workout_kml_creation_service.py
+++ b/fittrackee/tests/workouts/test_services/from_file/test_workout_kml_creation_service.py
@@ -1,9 +1,11 @@
-from io import BytesIO
-from typing import IO, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import gpxpy
 import pytest
 
+from fittrackee.tests.workouts.mixins import (
+    WorkoutFileMixin,
+)
 from fittrackee.workouts.exceptions import WorkoutFileException
 from fittrackee.workouts.services import WorkoutKmlCreationService
 
@@ -14,15 +16,7 @@ if TYPE_CHECKING:
     from fittrackee.workouts.models import Sport
 
 
-class WorkoutKmlCreationServiceTestCase:
-    @staticmethod
-    def get_file_content(content: str) -> IO[bytes]:
-        return BytesIO(str.encode(content))
-
-
-class TestWorkoutKmlCreationServiceParseFile(
-    WorkoutKmlCreationServiceTestCase
-):
+class TestWorkoutKmlCreationServiceParseFile(WorkoutFileMixin):
     def test_it_raises_error_when_kml_file_is_invalid(
         self, app: "Flask", invalid_kml_file: str
     ) -> None:
@@ -135,9 +129,7 @@ class TestWorkoutKmlCreationServiceParseFile(
         assert gpx.description is None
 
 
-class TestWorkoutKmlCreationServiceInstantiation(
-    WorkoutKmlCreationServiceTestCase
-):
+class TestWorkoutKmlCreationServiceInstantiation(WorkoutFileMixin):
     def test_it_instantiates_service(
         self,
         app: "Flask",

--- a/fittrackee/tests/workouts/test_services/from_file/test_workout_tcx_creation_service.py
+++ b/fittrackee/tests/workouts/test_services/from_file/test_workout_tcx_creation_service.py
@@ -108,10 +108,10 @@ class TestWorkoutTcxCreationServiceParseFile(WorkoutFileMixin):
         self,
         app: "Flask",
         sport_1_cycling: "Sport",
-        tcx_with_with_two_laps: str,
+        tcx_with_two_laps: str,
     ) -> None:
         gpx = WorkoutTcxCreationService.parse_file(
-            self.get_file_content(tcx_with_with_two_laps)
+            self.get_file_content(tcx_with_two_laps)
         )
 
         assert len(gpx.tracks) == 1
@@ -124,10 +124,10 @@ class TestWorkoutTcxCreationServiceParseFile(WorkoutFileMixin):
         self,
         app: "Flask",
         sport_1_cycling: "Sport",
-        tcx_with_with_two_activities: str,
+        tcx_with_two_activities: str,
     ) -> None:
         gpx = WorkoutTcxCreationService.parse_file(
-            self.get_file_content(tcx_with_with_two_activities)
+            self.get_file_content(tcx_with_two_activities)
         )
 
         assert len(gpx.tracks) == 1
@@ -135,6 +135,22 @@ class TestWorkoutTcxCreationServiceParseFile(WorkoutFileMixin):
         moving_data = gpx.get_moving_data()
         assert moving_data.moving_time == 235.0
         assert round(moving_data.moving_distance, 1) == 297.5
+
+    def test_it_ignores_invalid_elevation(
+        self,
+        app: "Flask",
+        sport_1_cycling: "Sport",
+        tcx_with_invalid_elevation: str,
+    ) -> None:
+        gpx = WorkoutTcxCreationService.parse_file(
+            self.get_file_content(tcx_with_invalid_elevation)
+        )
+
+        assert len(gpx.tracks) == 1
+        assert len(gpx.tracks[0].segments) == 1
+        elevations = gpx.tracks[0].segments[0].get_elevation_extremes()
+        assert elevations.minimum is None
+        assert elevations.maximum is None
 
 
 class TestWorkoutTcxCreationServiceInstantiation(WorkoutFileMixin):

--- a/fittrackee/tests/workouts/test_services/from_file/test_workout_tcx_creation_service.py
+++ b/fittrackee/tests/workouts/test_services/from_file/test_workout_tcx_creation_service.py
@@ -1,0 +1,134 @@
+from typing import TYPE_CHECKING
+
+import gpxpy
+import pytest
+
+from fittrackee.tests.workouts.mixins import (
+    WorkoutFileMixin,
+)
+from fittrackee.workouts.exceptions import WorkoutFileException
+from fittrackee.workouts.services import WorkoutTcxCreationService
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+    from fittrackee.users.models import User
+    from fittrackee.workouts.models import Sport
+
+
+class TestWorkoutTcxCreationServiceParseFile(WorkoutFileMixin):
+    def test_it_raises_error_when_cx_file_is_invalid(
+        self, app: "Flask", invalid_tcx_file: str
+    ) -> None:
+        with (
+            pytest.raises(
+                WorkoutFileException, match="error when parsing tcx file"
+            ),
+        ):
+            WorkoutTcxCreationService.parse_file(
+                self.get_file_content(invalid_tcx_file)
+            )
+
+    def test_it_raises_error_when_tcx_file_has_no_laps(
+        self, app: "Flask", sport_1_cycling: "Sport", tcx_file_wo_laps: str
+    ) -> None:
+        with (
+            pytest.raises(WorkoutFileException, match="no laps in tcx file"),
+        ):
+            WorkoutTcxCreationService.parse_file(
+                self.get_file_content(tcx_file_wo_laps)
+            )
+
+    def test_it_raises_error_when_tcx_file_has_no_tracks(
+        self, app: "Flask", sport_1_cycling: "Sport", tcx_file_wo_tracks: str
+    ) -> None:
+        with (
+            pytest.raises(WorkoutFileException, match="no tracks in tcx file"),
+        ):
+            WorkoutTcxCreationService.parse_file(
+                self.get_file_content(tcx_file_wo_tracks)
+            )
+
+    def test_it_return_gpx_with_tcx_with_one_lap_and_one_track(
+        self,
+        app: "Flask",
+        sport_1_cycling: "Sport",
+        tcx_with_one_lap_and_one_track: str,
+    ) -> None:
+        gpx = WorkoutTcxCreationService.parse_file(
+            self.get_file_content(tcx_with_one_lap_and_one_track)
+        )
+
+        assert isinstance(gpx, gpxpy.gpx.GPX)
+        assert len(gpx.tracks) == 1
+        assert gpx.tracks[0].name is None
+        assert gpx.tracks[0].description is None
+        assert len(gpx.tracks[0].segments) == 1
+        moving_data = gpx.get_moving_data()
+        assert moving_data.moving_time == 250.0
+        assert round(moving_data.moving_distance, 1) == 318.2
+
+    def test_it_return_gpx_with_tcx_with_one_lap_and_two_trackss(
+        self,
+        app: "Flask",
+        sport_1_cycling: "Sport",
+        user_1: "User",
+        tcx_with_one_lap_and_two_tracks: str,
+    ) -> None:
+        gpx = WorkoutTcxCreationService.parse_file(
+            self.get_file_content(tcx_with_one_lap_and_two_tracks)
+        )
+
+        assert len(gpx.tracks) == 1
+        assert len(gpx.tracks[0].segments) == 1
+        moving_data = gpx.get_moving_data()
+        assert moving_data.moving_time == 250.0
+        assert round(moving_data.moving_distance, 1) == 318.2
+
+    def test_it_return_gpx_with_tcx_with_two_laps(
+        self,
+        app: "Flask",
+        sport_1_cycling: "Sport",
+        tcx_with_with_two_laps: str,
+    ) -> None:
+        gpx = WorkoutTcxCreationService.parse_file(
+            self.get_file_content(tcx_with_with_two_laps)
+        )
+
+        assert len(gpx.tracks) == 1
+        assert len(gpx.tracks[0].segments) == 1
+        moving_data = gpx.get_moving_data()
+        assert moving_data.moving_time == 250.0
+        assert round(moving_data.moving_distance, 1) == 318.2
+
+
+class TestWorkoutTcxCreationServiceInstantiation(WorkoutFileMixin):
+    def test_it_instantiates_service(
+        self,
+        app: "Flask",
+        sport_1_cycling: "Sport",
+        user_1: "User",
+        tcx_with_one_lap_and_one_track: str,
+    ) -> None:
+        service = WorkoutTcxCreationService(
+            user_1,
+            self.get_file_content(tcx_with_one_lap_and_one_track),
+            sport_1_cycling.id,
+            sport_1_cycling.stopped_speed_threshold,
+        )
+
+        # from BaseWorkoutService
+        assert service.auth_user == user_1
+        assert service.sport_id == sport_1_cycling.id
+        # from BaseWorkoutWithSegmentsCreationService
+        assert service.coordinates == []
+        assert (
+            service.stopped_speed_threshold
+            == sport_1_cycling.stopped_speed_threshold
+        )
+        assert service.workout_name is None
+        assert service.workout_description is None
+        assert service.start_point is None
+        assert service.end_point is None
+        # from WorkoutGPXCreationService
+        assert isinstance(service.gpx, gpxpy.gpx.GPX)

--- a/fittrackee/tests/workouts/test_services/from_file/test_workout_tcx_creation_service.py
+++ b/fittrackee/tests/workouts/test_services/from_file/test_workout_tcx_creation_service.py
@@ -29,11 +29,28 @@ class TestWorkoutTcxCreationServiceParseFile(WorkoutFileMixin):
                 self.get_file_content(invalid_tcx_file)
             )
 
+    def test_it_raises_error_when_tcx_file_has_no_activities(
+        self,
+        app: "Flask",
+        sport_1_cycling: "Sport",
+        tcx_file_wo_activities: str,
+    ) -> None:
+        with (
+            pytest.raises(
+                WorkoutFileException, match="no activities in tcx file"
+            ),
+        ):
+            WorkoutTcxCreationService.parse_file(
+                self.get_file_content(tcx_file_wo_activities)
+            )
+
     def test_it_raises_error_when_tcx_file_has_no_laps(
         self, app: "Flask", sport_1_cycling: "Sport", tcx_file_wo_laps: str
     ) -> None:
         with (
-            pytest.raises(WorkoutFileException, match="no laps in tcx file"),
+            pytest.raises(
+                WorkoutFileException, match="no laps or no tracks in tcx file"
+            ),
         ):
             WorkoutTcxCreationService.parse_file(
                 self.get_file_content(tcx_file_wo_laps)
@@ -43,13 +60,15 @@ class TestWorkoutTcxCreationServiceParseFile(WorkoutFileMixin):
         self, app: "Flask", sport_1_cycling: "Sport", tcx_file_wo_tracks: str
     ) -> None:
         with (
-            pytest.raises(WorkoutFileException, match="no tracks in tcx file"),
+            pytest.raises(
+                WorkoutFileException, match="no laps or no tracks in tcx file"
+            ),
         ):
             WorkoutTcxCreationService.parse_file(
                 self.get_file_content(tcx_file_wo_tracks)
             )
 
-    def test_it_return_gpx_with_tcx_with_one_lap_and_one_track(
+    def test_it_returns_gpx_with_tcx_with_one_lap_and_one_track(
         self,
         app: "Flask",
         sport_1_cycling: "Sport",
@@ -68,7 +87,7 @@ class TestWorkoutTcxCreationServiceParseFile(WorkoutFileMixin):
         assert moving_data.moving_time == 250.0
         assert round(moving_data.moving_distance, 1) == 318.2
 
-    def test_it_return_gpx_with_tcx_with_one_lap_and_two_trackss(
+    def test_it_returns_gpx_with_tcx_with_one_lap_and_two_trackss(
         self,
         app: "Flask",
         sport_1_cycling: "Sport",
@@ -85,7 +104,7 @@ class TestWorkoutTcxCreationServiceParseFile(WorkoutFileMixin):
         assert moving_data.moving_time == 250.0
         assert round(moving_data.moving_distance, 1) == 318.2
 
-    def test_it_return_gpx_with_tcx_with_two_laps(
+    def test_it_returns_gpx_with_tcx_with_two_laps(
         self,
         app: "Flask",
         sport_1_cycling: "Sport",
@@ -100,6 +119,22 @@ class TestWorkoutTcxCreationServiceParseFile(WorkoutFileMixin):
         moving_data = gpx.get_moving_data()
         assert moving_data.moving_time == 250.0
         assert round(moving_data.moving_distance, 1) == 318.2
+
+    def test_it_returns_gpx_with_tcx_with_two_activities(
+        self,
+        app: "Flask",
+        sport_1_cycling: "Sport",
+        tcx_with_with_two_activities: str,
+    ) -> None:
+        gpx = WorkoutTcxCreationService.parse_file(
+            self.get_file_content(tcx_with_with_two_activities)
+        )
+
+        assert len(gpx.tracks) == 1
+        assert len(gpx.tracks[0].segments) == 2
+        moving_data = gpx.get_moving_data()
+        assert moving_data.moving_time == 235.0
+        assert round(moving_data.moving_distance, 1) == 297.5
 
 
 class TestWorkoutTcxCreationServiceInstantiation(WorkoutFileMixin):

--- a/fittrackee/tests/workouts/test_workouts_api_1_post.py
+++ b/fittrackee/tests/workouts/test_workouts_api_1_post.py
@@ -758,6 +758,58 @@ class TestPostWorkoutWithKmz(WorkoutApiTestCaseMixin):
         assert len(data["data"]["workouts"][0]["segments"]) == 2
 
 
+class TestPostWorkoutWithTcx(WorkoutApiTestCaseMixin):
+    def test_it_adds_a_workout_with_tcx_file(
+        self,
+        app: "Flask",
+        user_1: "User",
+        sport_1_cycling: "Sport",
+        tcx_with_one_lap_and_one_track: str,
+    ) -> None:
+        client, auth_token = self.get_test_client_and_auth_token(
+            app, user_1.email
+        )
+
+        response = client.post(
+            "/api/workouts",
+            data=dict(
+                file=(
+                    BytesIO(str.encode(tcx_with_one_lap_and_one_track)),
+                    "example.tcx",
+                ),
+                data='{"sport_id": 1}',
+            ),
+            headers=dict(
+                content_type="multipart/form-data",
+                Authorization=f"Bearer {auth_token}",
+            ),
+        )
+
+        assert response.status_code == 201
+        data = json.loads(response.data.decode())
+        assert "created" in data["status"]
+        assert len(data["data"]["workouts"]) == 1
+        assert data["data"]["workouts"][0]["title"] is not None
+        assert data["data"]["workouts"][0]["sport_id"] == 1
+        assert data["data"]["workouts"][0]["duration"] == "0:04:10"
+        assert data["data"]["workouts"][0]["ascent"] == 0.0
+        assert data["data"]["workouts"][0]["ave_speed"] == 4.58
+        assert data["data"]["workouts"][0]["descent"] == 21.0
+        assert data["data"]["workouts"][0]["description"] is None
+        assert data["data"]["workouts"][0]["distance"] == 0.318
+        assert data["data"]["workouts"][0]["max_alt"] == 997.0
+        assert data["data"]["workouts"][0]["max_speed"] == 5.11
+        assert data["data"]["workouts"][0]["min_alt"] == 976.0
+        assert data["data"]["workouts"][0]["moving"] == "0:04:10"
+        assert data["data"]["workouts"][0]["pauses"] is None
+        assert data["data"]["workouts"][0]["with_gpx"] is True
+        assert data["data"]["workouts"][0]["map"] is not None
+        assert data["data"]["workouts"][0]["weather_start"] is None
+        assert data["data"]["workouts"][0]["weather_end"] is None
+        assert data["data"]["workouts"][0]["notes"] is None
+        assert len(data["data"]["workouts"][0]["segments"]) == 1
+
+
 class TestPostWorkoutWithoutGpx(WorkoutApiTestCaseMixin):
     def test_it_returns_error_if_user_is_not_authenticated(
         self, app: "Flask", sport_1_cycling: "Sport", gpx_file: str

--- a/fittrackee/workouts/services/__init__.py
+++ b/fittrackee/workouts/services/__init__.py
@@ -3,6 +3,7 @@ from .workout_from_file import (
     WorkoutGpxCreationService,
     WorkoutKmlCreationService,
     WorkoutKmzCreationService,
+    WorkoutTcxCreationService,
 )
 from .workout_update_service import WorkoutUpdateService
 from .workouts_from_file_creation_service import (
@@ -15,6 +16,7 @@ __all__ = [
     "WorkoutGpxCreationService",
     "WorkoutKmlCreationService",
     "WorkoutKmzCreationService",
+    "WorkoutTcxCreationService",
     "WorkoutUpdateService",
     "WorkoutsFromArchiveCreationAsyncService",
     "WorkoutsFromFileCreationService",

--- a/fittrackee/workouts/services/workout_from_file/__init__.py
+++ b/fittrackee/workouts/services/workout_from_file/__init__.py
@@ -5,6 +5,7 @@ from .workout_gpx_creation_service import GpxInfo, WorkoutGpxCreationService
 from .workout_kml_creation_service import WorkoutKmlCreationService
 from .workout_kmz_creation_service import WorkoutKmzCreationService
 from .workout_point import WorkoutPoint
+from .workout_tcx_creation_service import WorkoutTcxCreationService
 
 __all__ = [
     "BaseWorkoutWithSegmentsCreationService",
@@ -13,4 +14,5 @@ __all__ = [
     "WorkoutKmlCreationService",
     "WorkoutKmzCreationService",
     "WorkoutPoint",
+    "WorkoutTcxCreationService",
 ]

--- a/fittrackee/workouts/services/workout_from_file/workout_tcx_creation_service.py
+++ b/fittrackee/workouts/services/workout_from_file/workout_tcx_creation_service.py
@@ -12,9 +12,12 @@ class WorkoutTcxCreationService(WorkoutGpxCreationService):
     @classmethod
     def parse_file(cls, workout_file: IO[bytes]) -> "gpxpy.gpx.GPX":
         """
-        tcx files contain laps, which contain tracks.
-        for now gpx file generated from tcx file contains only one track and
-        one segment.
+        Tcx files contain activities that contain laps containing tracks.
+        A gpx file generated from tcx file contains one track containing one
+        segment per activity.
+
+        TODO:
+        - handle multiple sports activities like Swimrun
         """
         try:
             tcx_dict = xmltodict.parse(workout_file)
@@ -30,53 +33,69 @@ class WorkoutTcxCreationService(WorkoutGpxCreationService):
         )
         if isinstance(activities, dict):
             activities = [activities]
-        laps = activities[0].get("Lap", [])
-        if isinstance(laps, dict):
-            laps = [laps]
 
-        if not laps:
+        if not activities:
             raise WorkoutFileException(
-                "error", "no laps in tcx file"
+                "error", "no activities in tcx file"
             ) from None
 
         gpx_track = gpxpy.gpx.GPXTrack()
-        gpx_segment = gpxpy.gpx.GPXTrackSegment()
-
         has_tracks = False
-        for lap in laps:
-            tcx_tracks = lap.get("Track", [])
-            if isinstance(tcx_tracks, dict):
-                tcx_tracks = [tcx_tracks]
-            if not tcx_tracks:
+        for activity in activities:
+            has_points = False
+            gpx_segment = gpxpy.gpx.GPXTrackSegment()
+            laps = activity.get("Lap", [])
+            if isinstance(laps, dict):
+                laps = [laps]
+            if not laps:
                 continue
 
-            for tcx_track in tcx_tracks:
-                has_tracks = True
-                points = tcx_track.get("Trackpoint", [])
-                if isinstance(points, dict):
-                    points = [points]
-                for point in points:
-                    coordinates = point.get("Position", {})
-                    if not coordinates:
-                        continue
-                    altitude = point.get("AltitudeMeters")
-                    gpx_segment.points.append(
-                        gpxpy.gpx.GPXTrackPoint(
-                            longitude=float(
-                                coordinates.get("LongitudeDegrees")
-                            ),
-                            latitude=float(coordinates.get("LatitudeDegrees")),
-                            elevation=float(altitude) if altitude else None,
-                            time=parse_time(point.get("Time")),
-                        )
-                    )
+            for lap in laps:
+                tcx_tracks = lap.get("Track", [])
+                if isinstance(tcx_tracks, dict):
+                    tcx_tracks = [tcx_tracks]
+                if not tcx_tracks:
+                    continue
 
-        if not has_tracks:
+                for tcx_track in tcx_tracks:
+                    has_tracks = True
+
+                    points = tcx_track.get("Trackpoint", [])
+                    if isinstance(points, dict):
+                        points = [points]
+
+                    if not points:
+                        continue
+
+                    for point in points:
+                        coordinates = point.get("Position", {})
+                        if not coordinates:
+                            continue
+                        altitude = point.get("AltitudeMeters")
+                        gpx_segment.points.append(
+                            gpxpy.gpx.GPXTrackPoint(
+                                longitude=float(
+                                    coordinates.get("LongitudeDegrees")
+                                ),
+                                latitude=float(
+                                    coordinates.get("LatitudeDegrees")
+                                ),
+                                elevation=float(altitude)
+                                if altitude
+                                else None,
+                                time=parse_time(point.get("Time")),
+                            )
+                        )
+                        has_points = True
+
+            if has_points:
+                gpx_track.segments.append(gpx_segment)
+
+        if not has_tracks or not gpx_track.segments:
             raise WorkoutFileException(
-                "error", "no tracks in tcx file"
+                "error", "no laps or no tracks in tcx file"
             ) from None
 
-        gpx_track.segments.append(gpx_segment)
         gpx = gpxpy.gpx.GPX()
         gpx.tracks.append(gpx_track)
         return gpx

--- a/fittrackee/workouts/services/workout_from_file/workout_tcx_creation_service.py
+++ b/fittrackee/workouts/services/workout_from_file/workout_tcx_creation_service.py
@@ -1,0 +1,82 @@
+from typing import IO
+
+import gpxpy.gpx
+import xmltodict
+from gpxpy.gpxfield import parse_time
+
+from ...exceptions import WorkoutFileException
+from .workout_gpx_creation_service import WorkoutGpxCreationService
+
+
+class WorkoutTcxCreationService(WorkoutGpxCreationService):
+    @classmethod
+    def parse_file(cls, workout_file: IO[bytes]) -> "gpxpy.gpx.GPX":
+        """
+        tcx files contain laps, which contain tracks.
+        for now gpx file generated from tcx file contains only one track and
+        one segment.
+        """
+        try:
+            tcx_dict = xmltodict.parse(workout_file)
+        except Exception as e:
+            raise WorkoutFileException(
+                "error", "error when parsing tcx file"
+            ) from e
+
+        activities = (
+            tcx_dict["TrainingCenterDatabase"]
+            .get("Activities", {})
+            .get("Activity", [])
+        )
+        if isinstance(activities, dict):
+            activities = [activities]
+        laps = activities[0].get("Lap", [])
+        if isinstance(laps, dict):
+            laps = [laps]
+
+        if not laps:
+            raise WorkoutFileException(
+                "error", "no laps in tcx file"
+            ) from None
+
+        gpx_track = gpxpy.gpx.GPXTrack()
+        gpx_segment = gpxpy.gpx.GPXTrackSegment()
+
+        has_tracks = False
+        for lap in laps:
+            tcx_tracks = lap.get("Track", [])
+            if isinstance(tcx_tracks, dict):
+                tcx_tracks = [tcx_tracks]
+            if not tcx_tracks:
+                continue
+
+            for tcx_track in tcx_tracks:
+                has_tracks = True
+                points = tcx_track.get("Trackpoint", [])
+                if isinstance(points, dict):
+                    points = [points]
+                for point in points:
+                    coordinates = point.get("Position", {})
+                    if not coordinates:
+                        continue
+                    altitude = point.get("AltitudeMeters")
+                    gpx_segment.points.append(
+                        gpxpy.gpx.GPXTrackPoint(
+                            longitude=float(
+                                coordinates.get("LongitudeDegrees")
+                            ),
+                            latitude=float(coordinates.get("LatitudeDegrees")),
+                            elevation=float(altitude) if altitude else None,
+                            time=parse_time(point.get("Time")),
+                        )
+                    )
+
+        if not has_tracks:
+            raise WorkoutFileException(
+                "error", "no tracks in tcx file"
+            ) from None
+
+        gpx_track.segments.append(gpx_segment)
+        gpx = gpxpy.gpx.GPX()
+        gpx.tracks.append(gpx_track)
+        return gpx

--- a/fittrackee/workouts/services/workouts_from_file_creation_service.py
+++ b/fittrackee/workouts/services/workouts_from_file_creation_service.py
@@ -32,6 +32,7 @@ from .workout_from_file import (
     WorkoutGpxCreationService,
     WorkoutKmlCreationService,
     WorkoutKmzCreationService,
+    WorkoutTcxCreationService,
 )
 
 if TYPE_CHECKING:
@@ -48,6 +49,7 @@ WORKOUT_FROM_FILE_SERVICES: Dict[
     "gpx": WorkoutGpxCreationService,
     "kml": WorkoutKmlCreationService,
     "kmz": WorkoutKmzCreationService,
+    "tcx": WorkoutTcxCreationService,
 }
 NO_FILE_ERROR_MESSAGE = "no workout file provided"
 

--- a/fittrackee_client/src/components/Workout/WorkoutEdition.vue
+++ b/fittrackee_client/src/components/Workout/WorkoutEdition.vue
@@ -66,7 +66,7 @@
                   id="gpxFile"
                   name="gpxFile"
                   type="file"
-                  accept=".gpx, .kml, .kmz, .zip"
+                  accept=".gpx, .kml, .kmz, .tcx, .zip"
                   :disabled="loading"
                   required
                   @invalid="invalidateForm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ quote-style = "double"
 "fittrackee/application/app_config.py" = ["E501"]
 "fittrackee/tests/test_email.py" = ["E501"]
 "fittrackee/tests/test_email_template_password_request.py" = ["E501"]
+"fittrackee/tests/fixtures/fixtures_workouts.py" = ["E501"]
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
see https://github.com/SamR1/FitTrackee/issues/529

Init support for TCX files:
- files are converted in gpx format to be analyzed with `gpxpy`
  - generated gpx file contains one track containing one segment per activity
- for now only time, longitude, latitude and elevation are handled (no heart rate for instance)
  - invalid values for elevation are ignored as workaround
