### PR TITLE
fix python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ RUN yarn build
 
 FROM python:3.13-alpine AS python-builder
 
-RUN apk add git
-
 RUN mkdir -p /usr/src/app/
 WORKDIR /usr/src/app/
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,7 +1,5 @@
 FROM python:3.13-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends git
-
 # set working directory
 RUN mkdir -p /usr/src/app/data/uploads /usr/src/app/data/logs
 WORKDIR /usr/src/app

--- a/poetry.lock
+++ b/poetry.lock
@@ -2955,24 +2955,20 @@ description = "Fork of staticmap, a small, python-based library for creating map
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "staticmap3-0.1.0-py3-none-any.whl", hash = "sha256:75e86a1a1aab18167d916176e3a96fa2ff61b619441d35dea4b1ec4f9990f7cd"},
+    {file = "staticmap3-0.1.0.tar.gz", hash = "sha256:310775444ec613baad856741b0fb6e126e96079f594dd08576ee7cbc33270db0"},
+]
 
 [package.dependencies]
 cachecontrol = ">=0.14.3"
-filelock = {version = ">=3.8.0", optional = true}
+filelock = {version = ">=3.8.0", optional = true, markers = "extra == \"filecache\""}
 pillow = ">=11.2.1"
 requests = ">=2.32.3"
 
 [package.extras]
 dev = ["mypy (>=1.15.0)", "ruff (>=0.11.10)", "types-requests"]
 filecache = ["filelock (>=3.8.0)"]
-
-[package.source]
-type = "git"
-url = "https://git@github.com/SamR1/staticmap.git"
-reference = "v0.1.0"
-resolved_reference = "ace22a57482e7a173c89e453e46e7545436b3f4a"
 
 [[package]]
 name = "stevedore"
@@ -3493,4 +3489,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.2"
-content-hash = "3ba93391c822b88670f05b54d1fae99ffb42e3499fc579980383b3c01dda4b4c"
+content-hash = "b3effcaece1be852f0cbb57336e3227014d77089076362290b294191cc79ae36"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ pyjwt = "^2.10.1"
 pyopenssl = "^25.1.0"
 pytz = "^2025.2"
 shortuuid = "^1.0.13"
-staticmap3 = {git = "https://git@github.com/SamR1/staticmap.git", rev = "v0.1.0", extras = ["filecache"]}
 sqlalchemy = "=2.0.41"
+staticmap3 = {extras = ["filecache"], version = "^0.1.0"}
 ua-parser = "^1.0.0"
 xmltodict = "^0.14.2"
 


### PR DESCRIPTION
PyPI does not allow direct dependency.
Therefore the fork of **Static Map** has been published to remove direct dependency.