### PR TITLE
Fix hr and cadence values when gpx points contain multiple values in extensions

### DIFF
--- a/fittrackee/tests/workouts/test_services/from_file/test_workout_gpx_creation_service.py
+++ b/fittrackee/tests/workouts/test_services/from_file/test_workout_gpx_creation_service.py
@@ -699,6 +699,32 @@ class TestWorkoutGpxCreationServiceProcessFile(
         assert workout.max_hr == 92
         assert workout.source == "Garmin Connect"
 
+    def test_it_creates_workout_when_gpx_file_has_gpxtpx_extensions_and_power(
+        self,
+        app: "Flask",
+        sport_1_cycling: Sport,
+        user_1: "User",
+        gpx_file_with_gpxtpx_extensions_and_power: str,
+    ) -> None:
+        service = self.init_service_with_gpx(
+            user_1, sport_1_cycling, gpx_file_with_gpxtpx_extensions_and_power
+        )
+
+        service.process_workout()
+        db.session.commit()
+
+        assert service.workout_description is None
+        assert service.workout_name is None
+        workout = Workout.query.one()
+        self.assert_workout(user_1, sport_1_cycling, workout)
+        self.assert_workout_segment(workout)
+        self.assert_workout_records(workout)
+        assert workout.ave_cadence == 52
+        assert workout.ave_hr == 85
+        assert workout.max_cadence == 57
+        assert workout.max_hr == 92
+        assert workout.source == "Garmin Connect"
+
     def test_it_creates_workout_when_gpx_file_has_cadence_float_value(
         self,
         app: "Flask",

--- a/fittrackee/workouts/services/workout_from_file/workout_gpx_creation_service.py
+++ b/fittrackee/workouts/services/workout_from_file/workout_gpx_creation_service.py
@@ -227,11 +227,12 @@ class WorkoutGpxCreationService(BaseWorkoutWithSegmentsCreationService):
                     )
 
             if point.extensions:
-                for element in point.extensions[0]:
-                    if element.tag.endswith("}hr") and element.text:
-                        heart_rates.append(int(element.text))
-                    if element.tag.endswith("}cad") and element.text:
-                        cadences.append(int(float(element.text)))
+                for extension in point.extensions:
+                    for element in extension:
+                        if element.tag.endswith("}hr") and element.text:
+                            heart_rates.append(int(element.text))
+                        if element.tag.endswith("}cad") and element.text:
+                            cadences.append(int(float(element.text)))
 
             # last segment point
             if point_idx == last_point_index:


### PR DESCRIPTION
In version v0.10.x, heart rate and cadence are ignored on workout creation, when points contain several values in addition to `TrackPointExtension`.

Example:
```xml
            <trkpt lat="redacted"
                   lon="redacted">
                <time>redacted</time>
                <ele>redacted</ele>
                <extensions>
                    <speed>13.13</speed>
                    <cadence>101</cadence>
                    <heartrate>139</heartrate>
                    <power>633</power>
                    <gpxtpx:TrackPointExtension>
                        <gpxtpx:hr>139</gpxtpx:hr>
                        <gpxtpx:cad>101</gpxtpx:cad>
                    </gpxtpx:TrackPointExtension>
                </extensions>
            </trkpt>
```

This PR fixes the calculation of max and average values for HR and cadence.