### PR TITLE
API - fix app config init to prevent multiple rows creation

### DIFF
--- a/fittrackee/application/exceptions.py
+++ b/fittrackee/application/exceptions.py
@@ -1,0 +1,6 @@
+class AppConfigException(Exception):
+    def __init__(self) -> None:
+        super().__init__(
+            "Error when getting configuration from database, "
+            "please restart the application."
+        )

--- a/fittrackee/application/utils.py
+++ b/fittrackee/application/utils.py
@@ -14,15 +14,19 @@ def get_or_init_config() -> AppConfig:
     """
     Init application configuration.
     """
-    existing_config = AppConfig.query.one_or_none()
-    if existing_config:
-        return existing_config
-    config = AppConfig()
-    config.max_users = 0  # no limitation
-    config.max_single_file_size = MAX_FILE_SIZE
-    config.max_zip_file_size = MAX_FILE_SIZE * 10
-    db.session.add(config)
-    db.session.commit()
+    with db.session.begin():
+        db.session.connection(
+            execution_options={"isolation_level": "SERIALIZABLE"}
+        )
+        existing_config = AppConfig.query.one_or_none()
+        if existing_config:
+            return existing_config
+        config = AppConfig()
+        config.max_users = 0  # no limitation
+        config.max_single_file_size = MAX_FILE_SIZE
+        config.max_zip_file_size = MAX_FILE_SIZE * 10
+        db.session.add(config)
+        db.session.commit()
     return config
 
 

--- a/fittrackee/application/utils.py
+++ b/fittrackee/application/utils.py
@@ -1,3 +1,4 @@
+import time
 from typing import Dict, List
 
 from flask import Flask
@@ -40,6 +41,7 @@ def get_or_init_config() -> AppConfig:
             except OperationalError:
                 db.session.rollback()
                 retries += 1
+                time.sleep(0.1)
     raise AppConfigException()
 
 

--- a/fittrackee/application/utils.py
+++ b/fittrackee/application/utils.py
@@ -1,10 +1,12 @@
 from typing import Dict, List
 
 from flask import Flask
+from sqlalchemy.exc import OperationalError
 
 from fittrackee import db
 
 from ..dates import get_datetime_in_utc
+from .exceptions import AppConfigException
 from .models import AppConfig
 
 MAX_FILE_SIZE = 1 * 1024 * 1024  # 1MB
@@ -14,20 +16,31 @@ def get_or_init_config() -> AppConfig:
     """
     Init application configuration.
     """
-    with db.session.begin():
-        db.session.connection(
-            execution_options={"isolation_level": "SERIALIZABLE"}
-        )
-        existing_config = AppConfig.query.one_or_none()
-        if existing_config:
-            return existing_config
-        config = AppConfig()
-        config.max_users = 0  # no limitation
-        config.max_single_file_size = MAX_FILE_SIZE
-        config.max_zip_file_size = MAX_FILE_SIZE * 10
-        db.session.add(config)
-        db.session.commit()
-    return config
+    retries = 0
+    while retries < 2:
+        with db.session.begin():
+            # Set isolation level to SERIALIZABLE to ensure that no other rows
+            # are created in 'app_config' table during transaction when
+            # several workers are started
+            db.session.connection(
+                execution_options={"isolation_level": "SERIALIZABLE"}
+            )
+            try:
+                existing_config = AppConfig.query.one_or_none()
+                if existing_config:
+                    return existing_config
+
+                config = AppConfig()
+                config.max_users = 0  # no limitation
+                config.max_single_file_size = MAX_FILE_SIZE
+                config.max_zip_file_size = MAX_FILE_SIZE * 10
+                db.session.add(config)
+                db.session.commit()
+                return config
+            except OperationalError:
+                db.session.rollback()
+                retries += 1
+    raise AppConfigException()
 
 
 def update_app_config_from_database(

--- a/fittrackee/tests/application/test_database_utils.py
+++ b/fittrackee/tests/application/test_database_utils.py
@@ -6,52 +6,59 @@ from fittrackee.application.utils import get_or_init_config
 
 class TestGetOrInitAppConfig:
     def test_it_creates_app_config(self, app_no_config: Flask) -> None:
-        get_or_init_config()
+        with app_no_config.app_context():
+            get_or_init_config()
 
-        assert AppConfig.query.count() == 1
+            assert AppConfig.query.count() == 1
 
     def test_it_inits_max_users_with_default_value(
         self, app_no_config: Flask
     ) -> None:
-        get_or_init_config()
+        with app_no_config.app_context():
+            get_or_init_config()
 
-        config = AppConfig.query.one()
-        assert config.max_users == 0
+            config = AppConfig.query.one()
+            assert config.max_users == 0
 
     def test_it_inits_max_single_file_size_with_default_value(
         self, app_no_config: Flask
     ) -> None:
-        get_or_init_config()
+        with app_no_config.app_context():
+            get_or_init_config()
 
-        config = AppConfig.query.one()
-        assert config.max_single_file_size == 1048576  # 1MB
+            config = AppConfig.query.one()
+            assert config.max_single_file_size == 1048576  # 1MB
 
     def test_it_inits_max_zip_file_size_with_default_value(
         self, app_no_config: Flask
     ) -> None:
-        get_or_init_config()
+        with app_no_config.app_context():
+            get_or_init_config()
 
-        config = AppConfig.query.one()
-        assert config.max_zip_file_size == 10485760  # 10MB
+            config = AppConfig.query.one()
+            assert config.max_zip_file_size == 10485760  # 10MB
 
     def test_it_inits_file_limit_import_with_default_value(
         self, app_no_config: Flask
     ) -> None:
-        get_or_init_config()
+        with app_no_config.app_context():
+            get_or_init_config()
 
-        config = AppConfig.query.one()
-        assert config.file_limit_import == 10
+            config = AppConfig.query.one()
+            assert config.file_limit_import == 10
 
     def test_it_inits_file_sync_limit_import_with_default_value(
         self, app_no_config: Flask
     ) -> None:
-        get_or_init_config()
+        with app_no_config.app_context():
+            get_or_init_config()
 
-        config = AppConfig.query.one()
-        assert config.file_sync_limit_import == 10
+            config = AppConfig.query.one()
+            assert config.file_sync_limit_import == 10
 
     def test_it_returns_existing_config(self, app: Flask) -> None:
-        config = get_or_init_config()
+        with app.app_context():
+            config = get_or_init_config()
 
-        assert config is not None
-        assert config.max_users == 100
+            assert config is not None
+            assert config.max_users == 100


### PR DESCRIPTION
see #855 

- set isolation level to `SERIALIZABLE` when creating first row in `app_config` table to prevent multiple rows creation