### PR TITLE
Fix async upload task creation when equipment is provided

### DIFF
--- a/fittrackee/tests/workouts/test_services/test_workouts_from_file_creation_service.py
+++ b/fittrackee/tests/workouts/test_services/test_workouts_from_file_creation_service.py
@@ -1622,7 +1622,7 @@ class TestWorkoutsFromFileCreationServiceAddWorkoutsUploadTask(
                 **workouts_data,
             },
             "files_to_process": TEST_FILES_LIST,
-            "equipment_ids": [equipment_bike_user_1.short_id],
+            "equipment_ids": [equipment_bike_user_1.id],
             "original_file_name": "workouts.zip",
         }
         assert upload_task.errored is False

--- a/fittrackee/workouts/services/workouts_from_file_creation_service.py
+++ b/fittrackee/workouts/services/workouts_from_file_creation_service.py
@@ -451,7 +451,7 @@ class WorkoutsFromFileCreationService(AbstractWorkoutsCreationService):
                 "equipment_ids": (
                     None
                     if equipments is None
-                    else [equipment.short_id for equipment in equipments]
+                    else [equipment.id for equipment in equipments]
                 ),
                 "original_file_name": self.file.filename,
             },


### PR DESCRIPTION
This PR fixes the error raised when a upload task is created with an equipment.