### PR TITLE
Update logging config to display log on the console

### DIFF
--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -104,6 +104,10 @@ deployment method.
 
     Path to log file
 
+    .. versionchanged:: 1.x.x
+
+    If the value is not set, logging output is displayed only on the console.
+
 
 .. envvar:: APP_SECRET_KEY
 

--- a/fittrackee/__init__.py
+++ b/fittrackee/__init__.py
@@ -34,11 +34,15 @@ REDIS_URL = os.getenv("REDIS_URL", "redis://")
 API_RATE_LIMITS = os.environ.get("API_RATE_LIMITS", "300 per 5 minutes").split(
     ","
 )
+
+log_handlers: list = [logging.StreamHandler()]
 log_file = os.getenv("APP_LOG")
+if log_file:
+    log_handlers.extend([logging.FileHandler(log_file)])
 logging.basicConfig(
-    filename=log_file,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     datefmt="%Y/%m/%d %H:%M:%S",
+    handlers=log_handlers,
 )
 appLog = logging.getLogger("fittrackee")
 


### PR DESCRIPTION
Application logs are now displayed on the console (and not only stored in application log file (see [`APP_LOG`](https://docs.fittrackee.org/en/installation.html#envvar-APP_LOG))).  
This allows application logs to be displayed in Docker logs (see https://github.com/SamR1/FitTrackee/issues/990#issuecomment-3638519889).