### PR TITLE
API - fix elevation service status when URLs are empty strings

### DIFF
--- a/fittrackee/application/app_config.py
+++ b/fittrackee/application/app_config.py
@@ -49,7 +49,8 @@ def get_application_config() -> Union[Dict, HttpResponse]:
           "about": null,
           "admin_contact": "admin@example.com",
           "elevation_services":	{
-            "open_elevation": false
+            "open_elevation": false,
+            "valhalla": false
           },
           "file_sync_limit_import": 10,
           "file_limit_import": 10,
@@ -111,7 +112,8 @@ def update_application_config(auth_user: User) -> Union[Dict, HttpResponse]:
           "about": null,
           "admin_contact": "admin@example.com",
           "elevation_services":	{
-            "open_elevation": false
+            "open_elevation": false,
+            "valhalla": false
           },
           "file_sync_limit_import": 10,
           "file_limit_import": 10,

--- a/fittrackee/application/models.py
+++ b/fittrackee/application/models.py
@@ -60,9 +60,9 @@ class AppConfig(BaseModel):
     def elevation_services(self) -> Dict:
         return {
             "open_elevation": (
-                current_app.config["OPEN_ELEVATION_API_URL"] is not None
+                current_app.config["OPEN_ELEVATION_API_URL"] != ""
             ),
-            "valhalla": current_app.config["VALHALLA_API_URL"] is not None,
+            "valhalla": current_app.config["VALHALLA_API_URL"] != "",
         }
 
     def serialize(self) -> Dict:

--- a/fittrackee/config.py
+++ b/fittrackee/config.py
@@ -52,8 +52,8 @@ class BaseConfig:
         "STATICMAP_SUBDOMAINS": os.environ.get("STATICMAP_SUBDOMAINS", ""),
     }
 
-    OPEN_ELEVATION_API_URL = os.environ.get("OPEN_ELEVATION_API_URL")
-    VALHALLA_API_URL = os.environ.get("VALHALLA_API_URL")
+    OPEN_ELEVATION_API_URL = os.environ.get("OPEN_ELEVATION_API_URL", "")
+    VALHALLA_API_URL = os.environ.get("VALHALLA_API_URL", "")
 
     DRAMATIQ_BROKER = broker
 

--- a/fittrackee/tests/application/test_app_config_model.py
+++ b/fittrackee/tests/application/test_app_config_model.py
@@ -204,3 +204,15 @@ class TestConfigModel:
             "open_elevation": True,
             "valhalla": True,
         }
+
+    def test_it_returns_elevation_services_when_valhalla_and_open_elevation_urls_are_empty_string(  # noqa
+        self, app_with_empty_string_as_open_elevation_and_valhalla_url: "Flask"
+    ) -> None:
+        config = AppConfig.query.one()
+
+        serialized_app_config = config.serialize()
+
+        assert serialized_app_config["elevation_services"] == {
+            "open_elevation": False,
+            "valhalla": False,
+        }

--- a/fittrackee/tests/fixtures/fixtures_app.py
+++ b/fittrackee/tests/fixtures/fixtures_app.py
@@ -235,6 +235,15 @@ def app_with_open_elevation_and_valhalla_url(
 
 
 @pytest.fixture
+def app_with_empty_string_as_open_elevation_and_valhalla_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator:
+    monkeypatch.setenv("OPEN_ELEVATION_API_URL", "")
+    monkeypatch.setenv("VALHALLA_API_URL", "")
+    yield from get_app(with_config=True)
+
+
+@pytest.fixture
 def app_with_global_map_workouts_limit_equal_to_1(
     monkeypatch: pytest.MonkeyPatch,
 ) -> Generator:

--- a/fittrackee/tests/workouts/test_services/elevation/test_open_elevation_service.py
+++ b/fittrackee/tests/workouts/test_services/elevation/test_open_elevation_service.py
@@ -36,7 +36,7 @@ class TestOpenElevationServiceInstantiation:
     ) -> None:
         service = OpenElevationService()
 
-        assert service.url is None
+        assert service.url == ""
         assert service.is_enabled is False
 
     def test_it_instantiates_service_when_open_elevation_api_url_is_set_in_env_var(  # noqa

--- a/fittrackee/tests/workouts/test_services/elevation/test_valhalla_elevation_service.py
+++ b/fittrackee/tests/workouts/test_services/elevation/test_valhalla_elevation_service.py
@@ -35,7 +35,7 @@ class TestValhallaElevationServiceInstantiation:
     ) -> None:
         service = ValhallaElevationService()
 
-        assert service.url is None
+        assert service.url == ""
         assert service.is_enabled is False
 
     def test_it_instantiates_service_when_valhalla_url_is_set_in_env_var(

--- a/fittrackee/users/models.py
+++ b/fittrackee/users/models.py
@@ -838,13 +838,13 @@ class User(BaseModel):
                 ElevationDataSource.OPEN_ELEVATION,
                 ElevationDataSource.OPEN_ELEVATION_SMOOTH,
             ]
-            and current_app.config["OPEN_ELEVATION_API_URL"] is None
+            and not current_app.config["OPEN_ELEVATION_API_URL"]
         ):
             return ElevationDataSource.FILE
 
         if (
             self.missing_elevations_processing == ElevationDataSource.VALHALLA
-            and current_app.config["VALHALLA_API_URL"] is None
+            and not current_app.config["VALHALLA_API_URL"]
         ):
             return ElevationDataSource.FILE
 

--- a/fittrackee/workouts/services/elevation/base_elevation_service.py
+++ b/fittrackee/workouts/services/elevation/base_elevation_service.py
@@ -1,6 +1,6 @@
 import os
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, List
 
 import numpy as np
 
@@ -24,12 +24,12 @@ class BaseElevationService(ABC):
 
     @property
     def is_enabled(self) -> bool:
-        return self.url is not None
+        return self.url != ""
 
-    def _get_api_url(self) -> Union[str, None]:
+    def _get_api_url(self) -> str:
         base_url = os.environ.get(self.config_key)
         if not base_url:
-            return None
+            return ""
         return self.url_pattern.format(base_url=base_url)
 
     @staticmethod


### PR DESCRIPTION
_feedback from matrix room_

This fix prevents the button for changing the elevation data source from being displayed when the elevation API URLs are empty strings.