### PR TITLE
Get product name from .fit file if exists + fix on pause events

### DIFF
--- a/fittrackee/workouts/services/workout_from_file/workout_fit_service.py
+++ b/fittrackee/workouts/services/workout_from_file/workout_fit_service.py
@@ -114,6 +114,7 @@ class WorkoutFitService(WorkoutGpxService):
                 ):
                     if (
                         segments_creation_event == "only_manual"
+                        and frame.has_field("timer_trigger")
                         and frame.get_value("timer_trigger") != "manual"
                     ):
                         continue

--- a/fittrackee/workouts/services/workout_from_file/workout_fit_service.py
+++ b/fittrackee/workouts/services/workout_from_file/workout_fit_service.py
@@ -64,6 +64,8 @@ class WorkoutFitService(WorkoutGpxService):
             if frame:
                 if frame.has_field("product_name"):
                     creator = frame.get_value("product_name")
+                    if isinstance(creator, str):
+                        creator = creator.capitalize()
                 elif frame.has_field("manufacturer"):
                     creator = (
                         frame.get_value("manufacturer")

--- a/fittrackee/workouts/services/workout_from_file/workout_fit_service.py
+++ b/fittrackee/workouts/services/workout_from_file/workout_fit_service.py
@@ -61,24 +61,27 @@ class WorkoutFitService(WorkoutGpxService):
                 lambda frame: frame.name == "file_id", data_frames
             )
             frame = next(file_id_frames, None)
-            if frame and frame.has_field("manufacturer"):
-                creator = (
-                    frame.get_value("manufacturer")
-                    if isinstance(frame.get_value("manufacturer"), str)
-                    else None
-                )
-                if (
-                    creator
-                    and frame.has_field("product")
-                    and frame.get_value("product")
-                ):
-                    product = frame.get_raw_value("product")
+            if frame:
+                if frame.has_field("product_name"):
+                    creator = frame.get_value("product_name")
+                elif frame.has_field("manufacturer"):
+                    creator = (
+                        frame.get_value("manufacturer")
+                        if isinstance(frame.get_value("manufacturer"), str)
+                        else None
+                    )
                     if (
-                        creator.lower() == "garmin"
-                        and product in GARMIN_DEVICES.keys()
+                        creator
+                        and frame.has_field("product")
+                        and frame.get_value("product")
                     ):
-                        product = GARMIN_DEVICES[product]
-                    creator = f"{creator} {product}"
+                        product = frame.get_raw_value("product")
+                        if (
+                            creator.lower() == "garmin"
+                            and product in GARMIN_DEVICES.keys()
+                        ):
+                            product = GARMIN_DEVICES[product]
+                        creator = f"{creator} {product}"
 
             # Get total calories from session
             # - total calories = resting + active calories


### PR DESCRIPTION
This PR allows to get device name from `product_name` field.

Some manufacturers store the device name in the `product_name`  field (for instance Coros or Suunto), unlike Garmin (the product id is stored in the `product` field).

Examples:

- Suunto

| before change | after change |
| --------------------  | ------------------- |
| <img width="315" height="64" alt="image" src="https://github.com/user-attachments/assets/55d154f7-7e5b-4cb4-9b5a-c13a2202c626" /> | <img width="323" height="58" alt="image" src="https://github.com/user-attachments/assets/36c53d23-6aad-4e99-b2d3-50e7a62f8158" /> |

- Coros

| before change | after change |
| --------------------  | ------------------- |
| <img width="227" height="62" alt="image" src="https://github.com/user-attachments/assets/4de3c191-9caf-4394-a983-93cee38c4075" />  | <img width="210" height="61" alt="image" src="https://github.com/user-attachments/assets/65c7c506-3571-4f78-af20-e384357b6741" /> |

> [!WARNING]
> Some devices may not store name in `product` field

- Garmin (unchanged)

| before change | after change |
| --------------------  | ------------------- |
|  <img width="313" height="56" alt="image" src="https://github.com/user-attachments/assets/58bf4fcb-b4a0-4a50-86bd-3d2ef938b36b" /> | <img width="314" height="65" alt="image" src="https://github.com/user-attachments/assets/44440b7a-0e23-48ce-b6d1-7f1e309f5707" /> |

The PR also fixes error when `time_trigger` does not exist in .fit file.
