### PR TITLE
fix: add pool_pre_ping to handle database restarts

### DIFF
--- a/fittrackee/__init__.py
+++ b/fittrackee/__init__.py
@@ -60,7 +60,7 @@ class Base(DeclarativeBase):
 
 db = SQLAlchemy(
     model_class=Base,
-    engine_options={"future": True},
+    engine_options={"future": True, "pool_pre_ping": True},
     session_options={"future": True},
 )
 


### PR DESCRIPTION
## Problem

Fixes #1099

When the database is restarted (e.g., during upgrades) while FitTrackee keeps running, the next database transaction fails because SQLAlchemy's connection pool holds stale connections that have been severed by the database server.

## Root Cause

The `SQLAlchemy` engine is created with only `engine_options={"future": True}`, without `pool_pre_ping`. This means SQLAlchemy does not verify that pooled connections are still alive before handing them to the application.

## Solution

Add `pool_pre_ping=True` to the engine options. This causes SQLAlchemy to emit a lightweight `SELECT 1` test before each checkout, automatically discarding and reconnecting stale connections.

```python
# Before
engine_options={"future": True}

# After
engine_options={"future": True, "pool_pre_ping": True}
```

This is the recommended approach per [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic).

## Testing

- The change is a single engine option addition with no behavioral side effects for healthy connections
- `pool_pre_ping` is a well-established SQLAlchemy feature used in production by countless Flask applications