### PR TITLE
fix: auto-activate user account when email sending is disabled

### DIFF
--- a/fittrackee/tests/fixtures/fixtures_app.py
+++ b/fittrackee/tests/fixtures/fixtures_app.py
@@ -174,6 +174,13 @@ def app_no_config(monkeypatch: pytest.MonkeyPatch) -> Generator:
 
 
 @pytest.fixture
+def app_wo_email(monkeypatch: pytest.MonkeyPatch) -> Generator:
+    if os.getenv("EMAIL_URL"):
+        monkeypatch.delenv("EMAIL_URL")
+    yield from get_app(with_config=True)
+
+
+@pytest.fixture
 def app_ssl(monkeypatch: pytest.MonkeyPatch) -> Generator:
     monkeypatch.setenv(
         "EMAIL_URL", "smtp://username:password@0.0.0.0:1025?ssl=True"

--- a/fittrackee/tests/users/test_users_service.py
+++ b/fittrackee/tests/users/test_users_service.py
@@ -775,7 +775,9 @@ class TestUserManagerServiceUserCreation:
         assert new_user.email == email
         assert bcrypt.check_password_hash(new_user.password, user_password)
 
-    def test_created_user_is_inactive(self, app: Flask) -> None:
+    def test_created_user_is_inactive_when_email_enabled(
+        self, app: Flask
+    ) -> None:
         username = random_string()
         user_manager_service = UserManagerService(username=username)
 
@@ -784,6 +786,18 @@ class TestUserManagerServiceUserCreation:
         assert new_user
         assert new_user.is_active is False
         assert new_user.confirmation_token is not None
+
+    def test_created_user_is_active_when_email_disabled(
+        self, app_wo_email: Flask
+    ) -> None:
+        username = random_string()
+        user_manager_service = UserManagerService(username=username)
+
+        new_user, _ = user_manager_service.create(email=random_email())
+
+        assert new_user
+        assert new_user.is_active is True
+        assert new_user.confirmation_token is None
 
     @pytest.mark.parametrize("input_role", [{}, {"role": "user"}])
     def test_created_user_has_user_role_when_role_not_provided(

--- a/fittrackee/users/users_service.py
+++ b/fittrackee/users/users_service.py
@@ -4,6 +4,8 @@ from typing import Optional, Tuple
 
 from sqlalchemy import func
 
+from flask import current_app
+
 from fittrackee import db
 from fittrackee.reports.models import ReportAction
 from fittrackee.users.constants import (
@@ -195,7 +197,11 @@ class UserManagerService:
         new_user = User(username=self.username, email=email, password=password)
         new_user.timezone = USER_TIMEZONE
         new_user.date_format = USER_DATE_FORMAT
-        new_user.confirmation_token = secrets.token_urlsafe(30)
+
+        if current_app.config.get("CAN_SEND_EMAILS"):
+            new_user.confirmation_token = secrets.token_urlsafe(30)
+        else:
+            new_user.is_active = True
 
         if role is not None:
             if role not in UserRole.db_choices():

--- a/fittrackee/users/users_service.py
+++ b/fittrackee/users/users_service.py
@@ -2,9 +2,8 @@ import secrets
 from datetime import datetime, timezone
 from typing import Optional, Tuple
 
-from sqlalchemy import func
-
 from flask import current_app
+from sqlalchemy import func
 
 from fittrackee import db
 from fittrackee.reports.models import ReportAction
@@ -198,7 +197,7 @@ class UserManagerService:
         new_user.timezone = USER_TIMEZONE
         new_user.date_format = USER_DATE_FORMAT
 
-        if current_app.config.get("CAN_SEND_EMAILS"):
+        if current_app.config["CAN_SEND_EMAILS"]:
             new_user.confirmation_token = secrets.token_urlsafe(30)
         else:
             new_user.is_active = True


### PR DESCRIPTION
## Summary

- When `EMAIL_URL` is not configured (`CAN_SEND_EMAILS` is `False`), newly registered users are now auto-activated instead of waiting for an email confirmation that will never arrive
- Adds `app_wo_email` test fixture and test covering the email-disabled registration path

Fixes #1103

## Changes

**`fittrackee/users/users_service.py`** — In `create_user()`, check `CAN_SEND_EMAILS` before generating a confirmation token. When email is disabled, set `is_active = True` directly.

**`fittrackee/tests/fixtures/fixtures_app.py`** — Add `app_wo_email` fixture (config loaded, no `EMAIL_URL`).

**`fittrackee/tests/users/test_users_service.py`** — Rename existing test to clarify it covers the email-enabled case. Add new test for email-disabled case asserting `is_active is True` and `confirmation_token is None`.

## Test plan

- [ ] Existing test `test_created_user_is_inactive_when_email_enabled` passes (renamed, same assertions)
- [ ] New test `test_created_user_is_active_when_email_disabled` passes
- [ ] Manual verification: deploy without `EMAIL_URL`, register → can log in immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)