### PR TITLE
Update message displayed after registration when email sending is disabled

### DIFF
--- a/fittrackee_client/src/components/User/UserAuthForm.vue
+++ b/fittrackee_client/src/components/User/UserAuthForm.vue
@@ -35,6 +35,9 @@
               }`
             )
           }}
+          <template v-if="!appConfig.is_email_sending_enabled">
+            {{ $t('user.ADMIN_WILL_REVIEW_AND_ACTIVATE_ACCOUNT') }}
+          </template>
         </div>
         <form
           :class="{ errors: formErrors }"

--- a/fittrackee_client/src/locales/en/user.json
+++ b/fittrackee_client/src/locales/en/user.json
@@ -5,6 +5,7 @@
   "ACCOUNT_SUSPENDED_AT": "Account suspended at {0}.",
   "ACTIVE_ACCOUNT": "The account is active",
   "ACTIVE_USER": "active user | active users",
+  "ADMIN_WILL_REVIEW_AND_ACTIVATE_ACCOUNT": "An administrator will review and activate your account if eligible.",
   "ALREADY_HAVE_ACCOUNT": "Already have an account?",
   "APPEAL": "Appeal",
   "APPEAL_APPROVED": "Appeal approved.",

--- a/fittrackee_client/src/locales/fr/user.json
+++ b/fittrackee_client/src/locales/fr/user.json
@@ -5,6 +5,7 @@
   "ACCOUNT_SUSPENDED_AT": "Compte suspendu le {0}.",
   "ACTIVE_ACCOUNT": "Le compte est actif",
   "ACTIVE_USER": "utilisateur actif | utilisateurs actifs",
+  "ADMIN_WILL_REVIEW_AND_ACTIVATE_ACCOUNT": "Un administrateur examinera votre compte et l'activera le cas échéant.",
   "ALREADY_HAVE_ACCOUNT": "Vous avez déjà un compte ?",
   "APPEAL": "Faire appel",
   "APPEAL_APPROVED": "Appel approuvé.",


### PR DESCRIPTION
see https://github.com/SamR1/FitTrackee/issues/1103#issuecomment-4250420240

- when email sending is disabled (updated message):

<img width="1080" height="979" src="https://github.com/user-attachments/assets/3cb915b0-a0c6-4d9a-a0e5-4b6d4161190b" />


- when email sending is enabled (message unchanged):

<img width="1080" height="979" src="https://github.com/user-attachments/assets/7b74ab92-7fbf-48a8-aaa3-a88d0687bac0" />
