### PR TITLE
fix pandas installation using Python 3.14 on CI

### DIFF
--- a/.github/workflows/.workflow-python.yml
+++ b/.github/workflows/.workflow-python.yml
@@ -41,15 +41,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Upgrade pip and setuptools
+        run: python -m pip install --upgrade pip setuptools
+
       - name: Install libgdal-dev in order to build numpy with python 3.14
         if: inputs.python-version == '3.14'
         run: |
           apt-get update
           apt-get install -y libgdal-dev
 
+      - name: Install numpy and pandas with python 3.14 (temporary workaround)
+        if: inputs.python-version == '3.14'
+        run: |
+          echo "meson<1.11.0" > build-constraint.txt
+          pip install numpy==2.2.6
+          pip install --build-constraint build-constraint.txt pandas==2.3.2
+
       - name: Install Poetry and Dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install --quiet poetry
           poetry config virtualenvs.create false
           poetry install --no-interaction --quiet

--- a/docsrc/source/installation/installation.rst
+++ b/docsrc/source/installation/installation.rst
@@ -15,7 +15,10 @@ Installation
     | Note that **FitTrackee** is under heavy development, some features may be unstable.
 
 .. note::
-    Depending on the operating system and the version of Python installed, additional dependencies may be required, such as **gcc** or **libgdal-dev**.
+    Depending on the operating system and the version of Python installed, additional dependencies may be required, such as **gcc** or **libgdal-dev** for numpy.
+
+.. note::
+    Errors can occurred when installing pandas with Python 3.14, see workaround in `troubleshooting <../troubleshooting/administrator.html#error-when-installing-pandas-using-python-3-14>`_.
 
 From PyPI
 *********

--- a/docsrc/source/troubleshooting/administrator.rst
+++ b/docsrc/source/troubleshooting/administrator.rst
@@ -97,3 +97,24 @@ Workouts created with a file are not displayed on the workouts map
 
 - | Since **gunicorn** 25.1.0, a `control interface <https://gunicorn.org/guides/gunicornc/>`__ is started by default and that may interfere with **prometheus** middleware (used by **dramatiq**).
   | A workaround for now is to disable this interface by adding ``--no-control-socket`` option to **gunicorn** command.
+
+
+Error when installing pandas using Python 3.14
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- | The following error can occur during **pandas** installation (version 2.3.2) using Python 3.14:
+
+  .. code-block::
+
+    ../pandas/_libs/tslibs/meson.build:32:7: ERROR: python.extension_module keyword argument 'dependencies' was of type array[str] but should have been array[Dependency | InternalDependency]
+
+  | The error is linked to the latest version of **meson** (see `Github issue <https://github.com/pandas-dev/pandas/issues/65213>`__). The temporary workaround is to install **pandas** with ``--build-constraint``, before installing **fittrackee**.
+  |
+  | After **libgdal-dev** installation if not present and virtualenv activation:
+
+  .. code-block:: bash
+
+     $ echo "meson<1.11.0" > build-constraint.txt
+     $ pip install numpy==2.2.6
+     $ pip install --build-constraint build-constraint.txt pandas==2.3.2
+     $ pip install fittrackee

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ lxml = "6.0.2"
 mistune = "3.2.0"
 nh3 = "0.3.3"
 numpy = "=2.2.6" # numpy 2.3+ requires python 3.11+. geoalchemy2 dependency.
-pandas = "=2.3.2" # temporary workaround to enable installation on RHEL 7, installation of 2.3.3 generates an error
+pandas = "=2.3.2" # temporary workaround to enable installation on RHEL 7, installation of 2.3.3 generates an error. With python 3.14, install with --build-constraint to avoid error, see documentation.
 psycopg2-binary = "2.9.11"
 pyjwt = "2.12.1"
 pyproj = "=3.7.1" # pyproj 3.7.2+ requires python 3.11+ and installation may generates an error on RHEL


### PR DESCRIPTION
see #1106 

The workaround is to install **pandas** with `--build-constraint` and **meson**<1.11.0, for instance:

```shell
$ echo "meson<1.11.0" > build-constraint.txt
$ pip install numpy==2.2.6
$ pip install --build-constraint build-constraint.txt pandas==2.3.2
$ pip install fittrackee
```